### PR TITLE
Fixed chips and small screen layouts

### DIFF
--- a/Density/app/src/main/res/drawable/chip_color_toggle.xml
+++ b/Density/app/src/main/res/drawable/chip_color_toggle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="#EFEFEF" android:state_checked="true"/>
-    <item android:color="@android:color/white" />
+    <item android:color="#EFEFEF" android:state_selected="true"/>
+    <item android:color="@android:color/transparent" />
 </selector>

--- a/Density/app/src/main/res/layout/facilities_activity.xml
+++ b/Density/app/src/main/res/layout/facilities_activity.xml
@@ -46,7 +46,9 @@
                     android:layout_height="match_parent"
                     android:checked="true"
                     android:text="@string/all"
-                    android:textAppearance="@style/ChipTextStyle"
+                    android:textAlignment="center"
+                    android:textColor="@android:color/black"
+                    android:textSize="13sp"
                     app:chipBackgroundColor="@drawable/chip_color_toggle" />
 
                 <com.google.android.material.chip.Chip
@@ -55,7 +57,9 @@
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
                     android:text="@string/north"
-                    android:textAppearance="@style/ChipTextStyle"
+                    android:textAlignment="center"
+                    android:textColor="@android:color/black"
+                    android:textSize="13sp"
                     app:chipBackgroundColor="@drawable/chip_color_toggle" />
 
                 <com.google.android.material.chip.Chip
@@ -64,7 +68,9 @@
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
                     android:text="@string/west"
-                    android:textAppearance="@style/ChipTextStyle"
+                    android:textAlignment="center"
+                    android:textColor="@android:color/black"
+                    android:textSize="13sp"
                     app:chipBackgroundColor="@drawable/chip_color_toggle" />
 
                 <com.google.android.material.chip.Chip
@@ -73,7 +79,9 @@
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
                     android:text="@string/central"
-                    android:textAppearance="@style/ChipTextStyle"
+                    android:textAlignment="center"
+                    android:textColor="@android:color/black"
+                    android:textSize="13sp"
                     app:chipBackgroundColor="@drawable/chip_color_toggle" />
 
             </com.google.android.material.chip.ChipGroup>

--- a/Density/app/src/main/res/layout/facilities_activity.xml
+++ b/Density/app/src/main/res/layout/facilities_activity.xml
@@ -48,7 +48,7 @@
                     android:text="@string/all"
                     android:textAlignment="center"
                     android:textColor="@android:color/black"
-                    android:textSize="13sp"
+                    android:textSize="@dimen/chip_text_size"
                     app:chipBackgroundColor="@drawable/chip_color_toggle" />
 
                 <com.google.android.material.chip.Chip
@@ -59,7 +59,7 @@
                     android:text="@string/north"
                     android:textAlignment="center"
                     android:textColor="@android:color/black"
-                    android:textSize="13sp"
+                    android:textSize="@dimen/chip_text_size"
                     app:chipBackgroundColor="@drawable/chip_color_toggle" />
 
                 <com.google.android.material.chip.Chip
@@ -70,7 +70,7 @@
                     android:text="@string/west"
                     android:textAlignment="center"
                     android:textColor="@android:color/black"
-                    android:textSize="13sp"
+                    android:textSize="@dimen/chip_text_size"
                     app:chipBackgroundColor="@drawable/chip_color_toggle" />
 
                 <com.google.android.material.chip.Chip
@@ -81,7 +81,7 @@
                     android:text="@string/central"
                     android:textAlignment="center"
                     android:textColor="@android:color/black"
-                    android:textSize="13sp"
+                    android:textSize="@dimen/chip_text_size"
                     app:chipBackgroundColor="@drawable/chip_color_toggle" />
 
             </com.google.android.material.chip.ChipGroup>

--- a/Density/app/src/main/res/layout/facility_info_page.xml
+++ b/Density/app/src/main/res/layout/facility_info_page.xml
@@ -212,7 +212,8 @@
                 android:gravity="center"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/todayHours" />
 
             <com.github.mikephil.charting.charts.BarChart
                 android:id="@+id/densityChart"
@@ -223,84 +224,103 @@
                 app:layout_constraintBottom_toTopOf="@+id/todayHours"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/dayChips" />
+                app:layout_constraintTop_toBottomOf="@id/chipScrollView" />
 
-            <com.google.android.material.chip.ChipGroup
-                android:id="@+id/dayChips"
-                android:layout_width="wrap_content"
+            <HorizontalScrollView
+                android:id="@+id/chipScrollView"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                app:chipSpacing="@dimen/chip_day_padding"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/popular_times"
-                app:singleLine="true"
-                app:singleSelection="true">
+                app:layout_constraintTop_toBottomOf="@id/popular_times">
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/mon"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
+                <com.google.android.material.chip.ChipGroup
+                    android:id="@+id/dayChips"
                     android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:checked="true"
-                    android:text="@string/M"
-                    android:textAppearance="@style/ChipTextStyle"
-                    app:chipBackgroundColor="@drawable/chip_color_toggle" />
+                    android:layout_height="wrap_content"
+                    app:chipSpacing="@dimen/chip_day_padding"
+                    app:singleLine="true"
+                    app:singleSelection="true">
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/tue"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:text="@string/Tu"
-                    android:textAppearance="@style/ChipTextStyle"
-                    app:chipBackgroundColor="@drawable/chip_color_toggle" />
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/mon"
+                        style="@style/Widget.MaterialComponents.Chip.Choice"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:checked="true"
+                        android:text="@string/M"
+                        android:textAlignment="center"
+                        android:textColor="@android:color/black"
+                        android:textSize="13sp"
+                        app:chipBackgroundColor="@drawable/chip_color_toggle" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/wed"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:text="@string/W"
-                    android:textAppearance="@style/ChipTextStyle"
-                    app:chipBackgroundColor="@drawable/chip_color_toggle" />
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/tue"
+                        style="@style/Widget.MaterialComponents.Chip.Choice"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:text="@string/Tu"
+                        android:textAlignment="center"
+                        android:textColor="@android:color/black"
+                        android:textSize="13sp"
+                        app:chipBackgroundColor="@drawable/chip_color_toggle" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/thu"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:text="@string/Th"
-                    android:textAppearance="@style/ChipTextStyle"
-                    app:chipBackgroundColor="@drawable/chip_color_toggle" />
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/wed"
+                        style="@style/Widget.MaterialComponents.Chip.Choice"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:text="@string/W"
+                        android:textAlignment="center"
+                        android:textColor="@android:color/black"
+                        android:textSize="13sp"
+                        app:chipBackgroundColor="@drawable/chip_color_toggle" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/fri"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:text="@string/F"
-                    android:textAppearance="@style/ChipTextStyle"
-                    app:chipBackgroundColor="@drawable/chip_color_toggle" />
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/thu"
+                        style="@style/Widget.MaterialComponents.Chip.Choice"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:text="@string/Th"
+                        android:textAlignment="center"
+                        android:textColor="@android:color/black"
+                        android:textSize="13sp"
+                        app:chipBackgroundColor="@drawable/chip_color_toggle" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/sat"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:text="@string/Sa"
-                    android:textAppearance="@style/ChipTextStyle"
-                    app:chipBackgroundColor="@drawable/chip_color_toggle" />
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/fri"
+                        style="@style/Widget.MaterialComponents.Chip.Choice"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:text="@string/F"
+                        android:textAlignment="center"
+                        android:textColor="@android:color/black"
+                        android:textSize="13sp"
+                        app:chipBackgroundColor="@drawable/chip_color_toggle" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/sun"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:text="@string/Su"
-                    android:textAppearance="@style/ChipTextStyle"
-                    app:chipBackgroundColor="@drawable/chip_color_toggle" />
-            </com.google.android.material.chip.ChipGroup>
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/sat"
+                        style="@style/Widget.MaterialComponents.Chip.Choice"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:text="@string/Sa"
+                        android:textAlignment="center"
+                        android:textColor="@android:color/black"
+                        android:textSize="13sp"
+                        app:chipBackgroundColor="@drawable/chip_color_toggle" />
+
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/sun"
+                        style="@style/Widget.MaterialComponents.Chip.Choice"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:text="@string/Su"
+                        android:textAlignment="center"
+                        android:textColor="@android:color/black"
+                        android:textSize="13sp"
+                        app:chipBackgroundColor="@drawable/chip_color_toggle" />
+                </com.google.android.material.chip.ChipGroup>
+            </HorizontalScrollView>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/Density/app/src/main/res/layout/facility_info_page.xml
+++ b/Density/app/src/main/res/layout/facility_info_page.xml
@@ -251,7 +251,7 @@
                         android:text="@string/M"
                         android:textAlignment="center"
                         android:textColor="@android:color/black"
-                        android:textSize="13sp"
+                        android:textSize="@dimen/chip_text_size"
                         app:chipBackgroundColor="@drawable/chip_color_toggle" />
 
                     <com.google.android.material.chip.Chip
@@ -262,7 +262,7 @@
                         android:text="@string/Tu"
                         android:textAlignment="center"
                         android:textColor="@android:color/black"
-                        android:textSize="13sp"
+                        android:textSize="@dimen/chip_text_size"
                         app:chipBackgroundColor="@drawable/chip_color_toggle" />
 
                     <com.google.android.material.chip.Chip
@@ -273,7 +273,7 @@
                         android:text="@string/W"
                         android:textAlignment="center"
                         android:textColor="@android:color/black"
-                        android:textSize="13sp"
+                        android:textSize="@dimen/chip_text_size"
                         app:chipBackgroundColor="@drawable/chip_color_toggle" />
 
                     <com.google.android.material.chip.Chip
@@ -284,7 +284,7 @@
                         android:text="@string/Th"
                         android:textAlignment="center"
                         android:textColor="@android:color/black"
-                        android:textSize="13sp"
+                        android:textSize="@dimen/chip_text_size"
                         app:chipBackgroundColor="@drawable/chip_color_toggle" />
 
                     <com.google.android.material.chip.Chip
@@ -295,7 +295,7 @@
                         android:text="@string/F"
                         android:textAlignment="center"
                         android:textColor="@android:color/black"
-                        android:textSize="13sp"
+                        android:textSize="@dimen/chip_text_size"
                         app:chipBackgroundColor="@drawable/chip_color_toggle" />
 
                     <com.google.android.material.chip.Chip
@@ -306,7 +306,7 @@
                         android:text="@string/Sa"
                         android:textAlignment="center"
                         android:textColor="@android:color/black"
-                        android:textSize="13sp"
+                        android:textSize="@dimen/chip_text_size"
                         app:chipBackgroundColor="@drawable/chip_color_toggle" />
 
                     <com.google.android.material.chip.Chip
@@ -317,7 +317,7 @@
                         android:text="@string/Su"
                         android:textAlignment="center"
                         android:textColor="@android:color/black"
-                        android:textSize="13sp"
+                        android:textSize="@dimen/chip_text_size"
                         app:chipBackgroundColor="@drawable/chip_color_toggle" />
                 </com.google.android.material.chip.ChipGroup>
             </HorizontalScrollView>

--- a/Density/app/src/main/res/values/chips.xml
+++ b/Density/app/src/main/res/values/chips.xml
@@ -3,4 +3,5 @@
     <dimen name="chip_group_margin">5dp</dimen>
     <dimen name="chip_day_padding">5dp</dimen>
     <dimen name="chip_day_group_margin">0dp</dimen>
+    <dimen name="chip_text_size">13sp</dimen>
 </resources>

--- a/Density/app/src/main/res/values/styles.xml
+++ b/Density/app/src/main/res/values/styles.xml
@@ -36,10 +36,6 @@
         <item name="queryBackground">@android:color/transparent</item>
     </style>
 
-    <style name="ChipTextStyle">
-        <item name="android:textSize">13sp</item>
-    </style>
-
     <style name="FullScreenDialog" parent="Theme.AppCompat.Light.Dialog">
         <item name="android:windowIsTranslucent">false</item>
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request addresses issues #26 and #39.  

Fixes for chips:

- chip text color stays black when selected
- chip text is centered (regardless of length of label)

Fixes for smaller screens: 

- chip group for historical data is now in a `HorizontalScrollView`, so all the days can still be accessed even on a small screen
- new constraints for the facility hours makes sure that text doesn't overlap

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
App behaves like it should before we bumped some versions. This time, we actually tried using the app on a smaller screen (Nexus 5 emulator).

