### PR TITLE
Day chips fixes

### DIFF
--- a/Density/app/src/main/java/org/cornelldti/density/density/facilitydetail/FacilityInfoPage.kt
+++ b/Density/app/src/main/java/org/cornelldti/density/density/facilitydetail/FacilityInfoPage.kt
@@ -26,6 +26,8 @@ import org.cornelldti.density.density.data.FacilityClass
 import org.cornelldti.density.density.data.MenuClass
 import org.cornelldti.density.density.util.FluxUtil
 import org.cornelldti.density.density.util.ValueFormatter
+import java.text.SimpleDateFormat
+import java.util.*
 
 
 class FacilityInfoPage : BaseActivity() {
@@ -70,19 +72,22 @@ class FacilityInfoPage : BaseActivity() {
     }
 
     private fun setDayChipOnClickListener() {
-        dayChips.setOnCheckedChangeListener { _, checkedId -> setDay(checkedId) }
+        dayChips.setOnCheckedChangeListener { _, checkedId ->
+            setDay(checkedId)
+            setDayMenu(checkedId)
+        }
     }
 
     private fun setDay(checkedId: Int) {
         var day = ""
         when (checkedId) {
-            R.id.sun -> day = "SUN"
-            R.id.mon -> day = "MON"
-            R.id.tue -> day = "TUE"
-            R.id.wed -> day = "WED"
-            R.id.thu -> day = "THU"
-            R.id.fri -> day = "FRI"
-            R.id.sat -> day = "SAT"
+            R.id.sun -> day = getString(R.string.SUN)
+            R.id.mon -> day = getString(R.string.MON)
+            R.id.tue -> day = getString(R.string.TUE)
+            R.id.wed -> day = getString(R.string.WED)
+            R.id.thu -> day = getString(R.string.THU)
+            R.id.fri -> day = getString(R.string.FRI)
+            R.id.sat -> day = getString(R.string.SAT)
             -1 -> dayChips.check(wasCheckedDay)
         }
         if (checkedId != -1 && wasCheckedDay != checkedId) {
@@ -90,6 +95,29 @@ class FacilityInfoPage : BaseActivity() {
             selectedDay = day
             fetchHistoricalJSON(day, facilityClass!!.id)
         }
+    }
+
+    private fun setDayMenu(checkedId: Int) {
+        var selectedDay = FluxUtil.dayString
+        when (checkedId) {
+            R.id.sun -> selectedDay = getString(R.string.SUN)
+            R.id.mon -> selectedDay = getString(R.string.MON)
+            R.id.tue -> selectedDay = getString(R.string.TUE)
+            R.id.wed -> selectedDay = getString(R.string.WED)
+            R.id.thu -> selectedDay = getString(R.string.THU)
+            R.id.fri -> selectedDay = getString(R.string.FRI)
+            R.id.sat -> selectedDay = getString(R.string.SAT)
+            -1 -> FluxUtil.dayString
+        }
+        val daysDifference = FluxUtil.getDayDifference(FluxUtil.dayString, selectedDay)
+        fetchMenuJSON(day = getDateDaysAfter(daysDifference), facilityId = facilityClass!!.id)
+    }
+
+    fun getDateDaysAfter(daysAfter: Int): String {
+        val calendar = Calendar.getInstance()
+        calendar.add(Calendar.DAY_OF_YEAR, daysAfter)
+        val format = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+        return format.format(calendar.time)
     }
 
     private fun setupBarChart() {
@@ -222,13 +250,13 @@ class FacilityInfoPage : BaseActivity() {
     private fun setToday(dayString: String) {
         selectedDay = dayString
         when (dayString) {
-            "SUN" -> sun.isChecked = true
-            "MON" -> mon.isChecked = true
-            "TUE" -> tue.isChecked = true
-            "WED" -> wed.isChecked = true
-            "THU" -> thu.isChecked = true
-            "FRI" -> fri.isChecked = true
-            "SAT" -> sat.isChecked = true
+            getString(R.string.SUN) -> sun.isChecked = true
+            getString(R.string.MON) -> mon.isChecked = true
+            getString(R.string.TUE) -> tue.isChecked = true
+            getString(R.string.WED) -> wed.isChecked = true
+            getString(R.string.THU) -> thu.isChecked = true
+            getString(R.string.FRI) -> fri.isChecked = true
+            getString(R.string.SAT) -> sat.isChecked = true
         }
         wasCheckedDay = dayChips.checkedChipId
     }
@@ -270,24 +298,40 @@ class FacilityInfoPage : BaseActivity() {
                 day = day,
                 facilityId = facilityId,
                 fetchMenuJSONOnResponse = { menu ->
-                    if (menu?.breakfastItems?.size == 0) {
-                        breakfast.isVisible = false
-                    }
-                    if (menu?.brunchItems?.size == 0) {
-                        brunch.isVisible = false
-                    }
-                    if (menu?.lunchItems?.size == 0) {
-                        lunch.isVisible = false
-                    }
-                    if (menu?.liteLunchItems?.size == 0) {
-                        lite_lunch.isVisible = false
-                    }
-                    if (menu?.dinnerItems?.size == 0) {
-                        dinner.isVisible = false
-                    }
-                    wasCheckedMenu = firstVisibleChipId(menu)
-                    showMenu(menu, wasCheckedMenu)
-                    menuChips.setOnCheckedChangeListener { _, checkedId -> showMenu(menu, checkedId) }
+                        if(menu?.breakfastItems?.size == 0 && menu?.brunchItems?.size == 0
+                                && menu?.lunchItems?.size == 0 && menu?.liteLunchItems?.size == 0 && menu?.dinnerItems?.size == 0) {
+                            menuCard.isVisible = false
+                        }
+                        else {
+                            menuCard.isVisible = true
+                            when {
+                                (menu?.breakfastItems?.size == 0) -> breakfast.isVisible = false
+                                else -> breakfast.isVisible = true
+                            }
+
+                            when {
+                                (menu?.brunchItems?.size == 0) -> brunch.isVisible = false
+                                else -> brunch.isVisible = true
+                            }
+
+                            when {
+                                (menu?.lunchItems?.size == 0) -> lunch.isVisible = false
+                                else -> lunch.isVisible = true
+                            }
+
+                            when {
+                                (menu?.liteLunchItems?.size == 0) -> lite_lunch.isVisible = false
+                                else -> lite_lunch.isVisible = true
+                            }
+
+                            when {
+                                (menu?.dinnerItems?.size == 0) -> dinner.isVisible = false
+                                else -> dinner.isVisible = true
+                            }
+                            wasCheckedMenu = firstVisibleChipId(menu)
+                            showMenu(menu, wasCheckedMenu)
+                            menuChips.setOnCheckedChangeListener { _, checkedId -> showMenu(menu, checkedId) }
+                        }
                 }
         )
     }

--- a/Density/app/src/main/java/org/cornelldti/density/density/facilitydetail/FacilityInfoPage.kt
+++ b/Density/app/src/main/java/org/cornelldti/density/density/facilitydetail/FacilityInfoPage.kt
@@ -110,14 +110,7 @@ class FacilityInfoPage : BaseActivity() {
             -1 -> FluxUtil.dayString
         }
         val daysDifference = FluxUtil.getDayDifference(FluxUtil.dayString, selectedDay)
-        fetchMenuJSON(day = getDateDaysAfter(daysDifference), facilityId = facilityClass!!.id)
-    }
-
-    fun getDateDaysAfter(daysAfter: Int): String {
-        val calendar = Calendar.getInstance()
-        calendar.add(Calendar.DAY_OF_YEAR, daysAfter)
-        val format = SimpleDateFormat("yyyy-MM-dd", Locale.US)
-        return format.format(calendar.time)
+        fetchMenuJSON(day = FluxUtil.getDateDaysAfter(daysDifference), facilityId = facilityClass!!.id)
     }
 
     private fun setupBarChart() {

--- a/Density/app/src/main/java/org/cornelldti/density/density/facilitydetail/FacilityInfoPage.kt
+++ b/Density/app/src/main/java/org/cornelldti/density/density/facilitydetail/FacilityInfoPage.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.content.ContextCompat
+import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -26,9 +27,6 @@ import org.cornelldti.density.density.data.FacilityClass
 import org.cornelldti.density.density.data.MenuClass
 import org.cornelldti.density.density.util.FluxUtil
 import org.cornelldti.density.density.util.ValueFormatter
-import java.text.SimpleDateFormat
-import java.util.*
-
 
 class FacilityInfoPage : BaseActivity() {
 
@@ -289,74 +287,60 @@ class FacilityInfoPage : BaseActivity() {
     private fun fetchMenuJSON(day: String, facilityId: String) {
         api.fetchMenuJSON(
                 day = day,
-                facilityId = facilityId,
-                fetchMenuJSONOnResponse = { menu ->
-                        if(menu?.breakfastItems?.size == 0 && menu?.brunchItems?.size == 0
-                                && menu?.lunchItems?.size == 0 && menu?.liteLunchItems?.size == 0 && menu?.dinnerItems?.size == 0) {
-                            menuCard.isVisible = false
-                        }
-                        else {
-                            menuCard.isVisible = true
-                            when {
-                                (menu?.breakfastItems?.size == 0) -> breakfast.isVisible = false
-                                else -> breakfast.isVisible = true
-                            }
-
-                            when {
-                                (menu?.brunchItems?.size == 0) -> brunch.isVisible = false
-                                else -> brunch.isVisible = true
-                            }
-
-                            when {
-                                (menu?.lunchItems?.size == 0) -> lunch.isVisible = false
-                                else -> lunch.isVisible = true
-                            }
-
-                            when {
-                                (menu?.liteLunchItems?.size == 0) -> lite_lunch.isVisible = false
-                                else -> lite_lunch.isVisible = true
-                            }
-
-                            when {
-                                (menu?.dinnerItems?.size == 0) -> dinner.isVisible = false
-                                else -> dinner.isVisible = true
-                            }
-                            wasCheckedMenu = firstVisibleChipId(menu)
-                            showMenu(menu, wasCheckedMenu)
-                            menuChips.setOnCheckedChangeListener { _, checkedId -> showMenu(menu, checkedId) }
-                        }
-                }
-        )
+                facilityId = facilityId
+        ) { menu ->
+            if (menu?.breakfastItems?.size == 0
+                    && menu.brunchItems.isEmpty()
+                    && menu.lunchItems.isEmpty()
+                    && menu.liteLunchItems.isEmpty()
+                    && menu.dinnerItems.isEmpty()) {
+                menuCard.isGone = true
+            } else {
+                menuCard.isVisible = true
+                breakfast.isVisible = menu?.breakfastItems?.isNotEmpty() ?: false
+                brunch.isVisible = menu?.brunchItems?.isNotEmpty() ?: false
+                lunch.isVisible = menu?.lunchItems?.isNotEmpty() ?: false
+                lite_lunch.isVisible = menu?.liteLunchItems?.isNotEmpty() ?: false
+                dinner.isVisible = menu?.dinnerItems?.isNotEmpty() ?: false
+                wasCheckedMenu = firstVisibleChipId(menu)
+                showMenu(menu, wasCheckedMenu)
+                menuChips.setOnCheckedChangeListener { _, checkedId -> showMenu(menu, checkedId) }
+            }
+        }
     }
 
     /**
      * Helper function that selects first visible chip and returns its ID
      */
     private fun firstVisibleChipId(menu: MenuClass?): Int {
-        when {
-            menu?.breakfastItems?.size!! > 0 -> {
-                breakfast.isChecked = true
-                return R.id.breakfast
+        if (menu != null) {
+            when {
+                menu.breakfastItems.isNotEmpty() -> {
+                    breakfast.isChecked = true
+                    return R.id.breakfast
+                }
+                menu.brunchItems.isNotEmpty() -> {
+                    brunch.isChecked = true
+                    return R.id.brunch
+                }
+                menu.lunchItems.isNotEmpty() -> {
+                    lunch.isChecked = true
+                    return R.id.lunch
+                }
+                menu.liteLunchItems.isNotEmpty() -> {
+                    lite_lunch.isChecked = true
+                    return R.id.lite_lunch
+                }
+                menu.dinnerItems.isNotEmpty() -> {
+                    dinner.isChecked = true
+                    return R.id.dinner
+                }
+                else -> {
+                    return -1
+                }
             }
-            menu.brunchItems.size > 0 -> {
-                brunch.isChecked = true
-                return R.id.brunch
-            }
-            menu.lunchItems.size > 0 -> {
-                lunch.isChecked = true
-                return R.id.lunch
-            }
-            menu.liteLunchItems.size > 0 -> {
-                lite_lunch.isChecked = true
-                return R.id.lite_lunch
-            }
-            menu.dinnerItems.size > 0 -> {
-                dinner.isChecked = true
-                return R.id.dinner
-            }
-            else -> {
-                return -1
-            }
+        } else {
+            return -1
         }
     }
 

--- a/Density/app/src/main/java/org/cornelldti/density/density/network/API.kt
+++ b/Density/app/src/main/java/org/cornelldti/density/density/network/API.kt
@@ -165,6 +165,7 @@ class API(context: Context) {
                 url = "$MENU_DATA_ENDPOINT?facility=$facilityId&date=$day",
                 onResponse = {response ->
                     fetchMenuJSONOnResponse(JsonParser.parseMenu(response, facilityId, day))
+                    Log.d("RESPON", response.toString())
                 },
                 onError = {
                     error -> Log.d("Error Fetching Menu", error.networkResponse.toString())

--- a/Density/app/src/main/java/org/cornelldti/density/density/util/FluxUtil.kt
+++ b/Density/app/src/main/java/org/cornelldti/density/density/util/FluxUtil.kt
@@ -5,6 +5,8 @@ import java.util.*
 
 object FluxUtil {
 
+    val daysList = listOf("SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT")
+
     val dayString: String
         get() = when (Calendar.getInstance().get(Calendar.DAY_OF_WEEK)) {
             Calendar.SUNDAY -> "SUN"
@@ -43,6 +45,16 @@ object FluxUtil {
         }
 
         return format.format(current.time)
+    }
+
+    fun getDayDifference(currentDay: String, tappedDay: String): Int {
+        var x: Int = daysList.indexOf(currentDay)
+        var count = 0
+        while (daysList[x % 7] != tappedDay) {
+            count += 1
+            x += 1
+        }
+        return count
     }
 
     /**

--- a/Density/app/src/main/java/org/cornelldti/density/density/util/FluxUtil.kt
+++ b/Density/app/src/main/java/org/cornelldti/density/density/util/FluxUtil.kt
@@ -57,6 +57,13 @@ object FluxUtil {
         return count
     }
 
+    fun getDateDaysAfter(daysAfter: Int): String {
+        val calendar = Calendar.getInstance()
+        calendar.add(Calendar.DAY_OF_YEAR, daysAfter)
+        val format = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+        return format.format(calendar.time)
+    }
+
     /**
      * getCurrentDate() provides the current date for the menu endpoint request.
      */

--- a/Density/app/src/main/res/drawable/chip_color_toggle.xml
+++ b/Density/app/src/main/res/drawable/chip_color_toggle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="#EFEFEF" android:state_selected="true"/>
+    <item android:color="@color/chip_background" android:state_selected="true"/>
     <item android:color="@android:color/transparent" />
 </selector>

--- a/Density/app/src/main/res/layout/facilities_activity.xml
+++ b/Density/app/src/main/res/layout/facilities_activity.xml
@@ -41,48 +41,32 @@
 
                 <com.google.android.material.chip.Chip
                     android:id="@+id/all"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
+                    style="@style/BaseChipStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
                     android:checked="true"
-                    android:text="@string/all"
-                    android:textAlignment="center"
-                    android:textColor="@android:color/black"
-                    android:textSize="@dimen/chip_text_size"
-                    app:chipBackgroundColor="@drawable/chip_color_toggle" />
+                    android:text="@string/all" />
 
                 <com.google.android.material.chip.Chip
                     android:id="@+id/north"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
+                    style="@style/BaseChipStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
-                    android:text="@string/north"
-                    android:textAlignment="center"
-                    android:textColor="@android:color/black"
-                    android:textSize="@dimen/chip_text_size"
-                    app:chipBackgroundColor="@drawable/chip_color_toggle" />
+                    android:text="@string/north" />
 
                 <com.google.android.material.chip.Chip
                     android:id="@+id/west"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
+                    style="@style/BaseChipStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
-                    android:text="@string/west"
-                    android:textAlignment="center"
-                    android:textColor="@android:color/black"
-                    android:textSize="@dimen/chip_text_size"
-                    app:chipBackgroundColor="@drawable/chip_color_toggle" />
+                    android:text="@string/west" />
 
                 <com.google.android.material.chip.Chip
                     android:id="@+id/central"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
+                    style="@style/BaseChipStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="match_parent"
-                    android:text="@string/central"
-                    android:textAlignment="center"
-                    android:textColor="@android:color/black"
-                    android:textSize="@dimen/chip_text_size"
-                    app:chipBackgroundColor="@drawable/chip_color_toggle" />
+                    android:text="@string/central" />
 
             </com.google.android.material.chip.ChipGroup>
 

--- a/Density/app/src/main/res/layout/facility_info_page.xml
+++ b/Density/app/src/main/res/layout/facility_info_page.xml
@@ -137,13 +137,112 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
                 android:layout_marginEnd="16dp"
-                android:layout_marginBottom="16dp"
                 android:gravity="end"
                 android:text="@string/accuracy"
                 android:textSize="12sp"
                 android:textStyle="italic"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/current_view" />
+
+            <HorizontalScrollView
+                android:id="@+id/chipScrollView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                app:layout_constraintBottom_toTopOf="@id/historicalDataCard"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/accuracy">
+
+                <com.google.android.material.chip.ChipGroup
+                    android:id="@+id/dayChips"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="16dp"
+                    android:layout_marginRight="16dp"
+                    app:chipSpacingHorizontal="@dimen/chip_day_padding"
+                    app:singleLine="true"
+                    app:singleSelection="true">
+
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/sun"
+                        style="@style/Widget.MaterialComponents.Chip.Choice"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:checked="true"
+                        android:text="@string/Su"
+                        android:textAlignment="center"
+                        android:textColor="@android:color/black"
+                        android:textSize="@dimen/chip_text_size"
+                        app:chipBackgroundColor="@drawable/chip_color_toggle" />
+
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/mon"
+                        style="@style/Widget.MaterialComponents.Chip.Choice"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:text="@string/M"
+                        android:textAlignment="center"
+                        android:textColor="@android:color/black"
+                        android:textSize="@dimen/chip_text_size"
+                        app:chipBackgroundColor="@drawable/chip_color_toggle" />
+
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/tue"
+                        style="@style/Widget.MaterialComponents.Chip.Choice"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:text="@string/T"
+                        android:textAlignment="center"
+                        android:textColor="@android:color/black"
+                        android:textSize="@dimen/chip_text_size"
+                        app:chipBackgroundColor="@drawable/chip_color_toggle" />
+
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/wed"
+                        style="@style/Widget.MaterialComponents.Chip.Choice"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:text="@string/W"
+                        android:textAlignment="center"
+                        android:textColor="@android:color/black"
+                        android:textSize="@dimen/chip_text_size"
+                        app:chipBackgroundColor="@drawable/chip_color_toggle" />
+
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/thu"
+                        style="@style/Widget.MaterialComponents.Chip.Choice"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:text="@string/Th"
+                        android:textAlignment="center"
+                        android:textColor="@android:color/black"
+                        android:textSize="@dimen/chip_text_size"
+                        app:chipBackgroundColor="@drawable/chip_color_toggle" />
+
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/fri"
+                        style="@style/Widget.MaterialComponents.Chip.Choice"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:text="@string/F"
+                        android:textAlignment="center"
+                        android:textColor="@android:color/black"
+                        android:textSize="@dimen/chip_text_size"
+                        app:chipBackgroundColor="@drawable/chip_color_toggle" />
+
+                    <com.google.android.material.chip.Chip
+                        android:id="@+id/sat"
+                        style="@style/Widget.MaterialComponents.Chip.Choice"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:text="@string/S"
+                        android:textAlignment="center"
+                        android:textColor="@android:color/black"
+                        android:textSize="@dimen/chip_text_size"
+                        app:chipBackgroundColor="@drawable/chip_color_toggle" />
+                </com.google.android.material.chip.ChipGroup>
+            </HorizontalScrollView>
 
             <androidx.cardview.widget.CardView
                 android:id="@+id/historicalDataCard"
@@ -153,7 +252,7 @@
                 android:layout_margin="16dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/accuracy">
+                app:layout_constraintTop_toBottomOf="@id/chipScrollView">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
@@ -174,102 +273,6 @@
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent" />
 
-                    <HorizontalScrollView
-                        android:id="@+id/chipScrollView"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/popular_times">
-
-                        <com.google.android.material.chip.ChipGroup
-                            android:id="@+id/dayChips"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            app:chipSpacingHorizontal="@dimen/chip_day_padding"
-                            app:singleLine="true"
-                            app:singleSelection="true">
-
-                            <com.google.android.material.chip.Chip
-                                android:id="@+id/mon"
-                                style="@style/Widget.MaterialComponents.Chip.Choice"
-                                android:layout_width="wrap_content"
-                                android:layout_height="match_parent"
-                                android:checked="true"
-                                android:text="@string/M"
-                                android:textAlignment="center"
-                                android:textColor="@android:color/black"
-                                android:textSize="@dimen/chip_text_size"
-                                app:chipBackgroundColor="@drawable/chip_color_toggle" />
-
-                            <com.google.android.material.chip.Chip
-                                android:id="@+id/tue"
-                                style="@style/Widget.MaterialComponents.Chip.Choice"
-                                android:layout_width="wrap_content"
-                                android:layout_height="match_parent"
-                                android:text="@string/Tu"
-                                android:textAlignment="center"
-                                android:textColor="@android:color/black"
-                                android:textSize="@dimen/chip_text_size"
-                                app:chipBackgroundColor="@drawable/chip_color_toggle" />
-
-                            <com.google.android.material.chip.Chip
-                                android:id="@+id/wed"
-                                style="@style/Widget.MaterialComponents.Chip.Choice"
-                                android:layout_width="wrap_content"
-                                android:layout_height="match_parent"
-                                android:text="@string/W"
-                                android:textAlignment="center"
-                                android:textColor="@android:color/black"
-                                android:textSize="@dimen/chip_text_size"
-                                app:chipBackgroundColor="@drawable/chip_color_toggle" />
-
-                            <com.google.android.material.chip.Chip
-                                android:id="@+id/thu"
-                                style="@style/Widget.MaterialComponents.Chip.Choice"
-                                android:layout_width="wrap_content"
-                                android:layout_height="match_parent"
-                                android:text="@string/Th"
-                                android:textAlignment="center"
-                                android:textColor="@android:color/black"
-                                android:textSize="@dimen/chip_text_size"
-                                app:chipBackgroundColor="@drawable/chip_color_toggle" />
-
-                            <com.google.android.material.chip.Chip
-                                android:id="@+id/fri"
-                                style="@style/Widget.MaterialComponents.Chip.Choice"
-                                android:layout_width="wrap_content"
-                                android:layout_height="match_parent"
-                                android:text="@string/F"
-                                android:textAlignment="center"
-                                android:textColor="@android:color/black"
-                                android:textSize="@dimen/chip_text_size"
-                                app:chipBackgroundColor="@drawable/chip_color_toggle" />
-
-                            <com.google.android.material.chip.Chip
-                                android:id="@+id/sat"
-                                style="@style/Widget.MaterialComponents.Chip.Choice"
-                                android:layout_width="wrap_content"
-                                android:layout_height="match_parent"
-                                android:text="@string/Sa"
-                                android:textAlignment="center"
-                                android:textColor="@android:color/black"
-                                android:textSize="@dimen/chip_text_size"
-                                app:chipBackgroundColor="@drawable/chip_color_toggle" />
-
-                            <com.google.android.material.chip.Chip
-                                android:id="@+id/sun"
-                                style="@style/Widget.MaterialComponents.Chip.Choice"
-                                android:layout_width="wrap_content"
-                                android:layout_height="match_parent"
-                                android:text="@string/Su"
-                                android:textAlignment="center"
-                                android:textColor="@android:color/black"
-                                android:textSize="@dimen/chip_text_size"
-                                app:chipBackgroundColor="@drawable/chip_color_toggle" />
-                        </com.google.android.material.chip.ChipGroup>
-                    </HorizontalScrollView>
-
                     <com.github.mikephil.charting.charts.BarChart
                         android:id="@+id/densityChart"
                         android:layout_width="match_parent"
@@ -279,7 +282,7 @@
                         app:layout_constraintBottom_toTopOf="@+id/todayHours"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/chipScrollView" />
+                        app:layout_constraintTop_toBottomOf="@id/popular_times" />
 
                     <TextView
                         android:id="@+id/todayHours"

--- a/Density/app/src/main/res/layout/facility_info_page.xml
+++ b/Density/app/src/main/res/layout/facility_info_page.xml
@@ -144,105 +144,69 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/current_view" />
 
-            <HorizontalScrollView
-                android:id="@+id/chipScrollView"
-                android:layout_width="match_parent"
+            <com.google.android.material.chip.ChipGroup
+                android:id="@+id/dayChips"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="10dp"
-                app:layout_constraintBottom_toTopOf="@id/historicalDataCard"
+                android:layout_marginBottom="16dp"
+                app:chipSpacingHorizontal="0dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/accuracy">
+                app:layout_constraintTop_toBottomOf="@+id/accuracy"
+                app:singleLine="true"
+                app:singleSelection="true">
 
-                <com.google.android.material.chip.ChipGroup
-                    android:id="@+id/dayChips"
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/sun"
+                    style="@style/OutlineChipStyle"
                     android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="16dp"
-                    android:layout_marginRight="16dp"
-                    app:chipSpacingHorizontal="@dimen/chip_day_padding"
-                    app:singleLine="true"
-                    app:singleSelection="true">
+                    android:layout_height="match_parent"
+                    android:checked="true"
+                    android:text="@string/Su" />
 
-                    <com.google.android.material.chip.Chip
-                        android:id="@+id/sun"
-                        style="@style/Widget.MaterialComponents.Chip.Choice"
-                        android:layout_width="wrap_content"
-                        android:layout_height="match_parent"
-                        android:checked="true"
-                        android:text="@string/Su"
-                        android:textAlignment="center"
-                        android:textColor="@android:color/black"
-                        android:textSize="@dimen/chip_text_size"
-                        app:chipBackgroundColor="@drawable/chip_color_toggle" />
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/mon"
+                    style="@style/OutlineChipStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:text="@string/M" />
 
-                    <com.google.android.material.chip.Chip
-                        android:id="@+id/mon"
-                        style="@style/Widget.MaterialComponents.Chip.Choice"
-                        android:layout_width="wrap_content"
-                        android:layout_height="match_parent"
-                        android:text="@string/M"
-                        android:textAlignment="center"
-                        android:textColor="@android:color/black"
-                        android:textSize="@dimen/chip_text_size"
-                        app:chipBackgroundColor="@drawable/chip_color_toggle" />
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/tue"
+                    style="@style/OutlineChipStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:text="@string/T" />
 
-                    <com.google.android.material.chip.Chip
-                        android:id="@+id/tue"
-                        style="@style/Widget.MaterialComponents.Chip.Choice"
-                        android:layout_width="wrap_content"
-                        android:layout_height="match_parent"
-                        android:text="@string/T"
-                        android:textAlignment="center"
-                        android:textColor="@android:color/black"
-                        android:textSize="@dimen/chip_text_size"
-                        app:chipBackgroundColor="@drawable/chip_color_toggle" />
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/wed"
+                    style="@style/OutlineChipStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:text="@string/W" />
 
-                    <com.google.android.material.chip.Chip
-                        android:id="@+id/wed"
-                        style="@style/Widget.MaterialComponents.Chip.Choice"
-                        android:layout_width="wrap_content"
-                        android:layout_height="match_parent"
-                        android:text="@string/W"
-                        android:textAlignment="center"
-                        android:textColor="@android:color/black"
-                        android:textSize="@dimen/chip_text_size"
-                        app:chipBackgroundColor="@drawable/chip_color_toggle" />
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/thu"
+                    style="@style/OutlineChipStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:text="@string/Th" />
 
-                    <com.google.android.material.chip.Chip
-                        android:id="@+id/thu"
-                        style="@style/Widget.MaterialComponents.Chip.Choice"
-                        android:layout_width="wrap_content"
-                        android:layout_height="match_parent"
-                        android:text="@string/Th"
-                        android:textAlignment="center"
-                        android:textColor="@android:color/black"
-                        android:textSize="@dimen/chip_text_size"
-                        app:chipBackgroundColor="@drawable/chip_color_toggle" />
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/fri"
+                    style="@style/OutlineChipStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:text="@string/F" />
 
-                    <com.google.android.material.chip.Chip
-                        android:id="@+id/fri"
-                        style="@style/Widget.MaterialComponents.Chip.Choice"
-                        android:layout_width="wrap_content"
-                        android:layout_height="match_parent"
-                        android:text="@string/F"
-                        android:textAlignment="center"
-                        android:textColor="@android:color/black"
-                        android:textSize="@dimen/chip_text_size"
-                        app:chipBackgroundColor="@drawable/chip_color_toggle" />
-
-                    <com.google.android.material.chip.Chip
-                        android:id="@+id/sat"
-                        style="@style/Widget.MaterialComponents.Chip.Choice"
-                        android:layout_width="wrap_content"
-                        android:layout_height="match_parent"
-                        android:text="@string/S"
-                        android:textAlignment="center"
-                        android:textColor="@android:color/black"
-                        android:textSize="@dimen/chip_text_size"
-                        app:chipBackgroundColor="@drawable/chip_color_toggle" />
-                </com.google.android.material.chip.ChipGroup>
-            </HorizontalScrollView>
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/sat"
+                    style="@style/OutlineChipStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:text="@string/S" />
+            </com.google.android.material.chip.ChipGroup>
 
             <androidx.cardview.widget.CardView
                 android:id="@+id/historicalDataCard"
@@ -252,7 +216,7 @@
                 android:layout_margin="16dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/chipScrollView">
+                app:layout_constraintTop_toBottomOf="@id/dayChips">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
@@ -316,7 +280,6 @@
                 android:id="@+id/menuCard"
                 style="@style/MyCardView"
                 android:layout_width="0dp"
-                android:visibility="invisible"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"
@@ -347,7 +310,8 @@
                         android:id="@+id/menuChips"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        app:chipSpacingHorizontal="@dimen/chip_day_padding"
+                        app:chipSpacingHorizontal="0dp"
+                        app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/menu"
                         app:singleLine="true"
@@ -355,58 +319,38 @@
 
                         <com.google.android.material.chip.Chip
                             android:id="@+id/breakfast"
-                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            style="@style/BaseChipStyle"
                             android:layout_width="wrap_content"
                             android:layout_height="match_parent"
-                            android:text="@string/breakfast"
-                            android:textAlignment="center"
-                            android:textColor="@android:color/black"
-                            android:textSize="@dimen/chip_text_size"
-                            app:chipBackgroundColor="@drawable/chip_color_toggle" />
+                            android:text="@string/breakfast" />
 
                         <com.google.android.material.chip.Chip
                             android:id="@+id/brunch"
-                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            style="@style/BaseChipStyle"
                             android:layout_width="wrap_content"
                             android:layout_height="match_parent"
-                            android:text="@string/brunch"
-                            android:textAlignment="center"
-                            android:textColor="@android:color/black"
-                            android:textSize="@dimen/chip_text_size"
-                            app:chipBackgroundColor="@drawable/chip_color_toggle" />
+                            android:text="@string/brunch" />
 
                         <com.google.android.material.chip.Chip
                             android:id="@+id/lunch"
-                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            style="@style/BaseChipStyle"
                             android:layout_width="wrap_content"
                             android:layout_height="match_parent"
-                            android:text="@string/lunch"
-                            android:textAlignment="center"
-                            android:textColor="@android:color/black"
-                            android:textSize="@dimen/chip_text_size"
-                            app:chipBackgroundColor="@drawable/chip_color_toggle" />
+                            android:text="@string/lunch" />
 
                         <com.google.android.material.chip.Chip
                             android:id="@+id/lite_lunch"
-                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            style="@style/BaseChipStyle"
                             android:layout_width="wrap_content"
                             android:layout_height="match_parent"
-                            android:text="@string/lite_lunch"
-                            android:textAlignment="center"
-                            android:textColor="@android:color/black"
-                            android:textSize="@dimen/chip_text_size"
-                            app:chipBackgroundColor="@drawable/chip_color_toggle" />
+                            android:text="@string/lite_lunch" />
 
                         <com.google.android.material.chip.Chip
                             android:id="@+id/dinner"
-                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            style="@style/BaseChipStyle"
                             android:layout_width="wrap_content"
                             android:layout_height="match_parent"
-                            android:text="@string/dinner"
-                            android:textAlignment="center"
-                            android:textColor="@android:color/black"
-                            android:textSize="@dimen/chip_text_size"
-                            app:chipBackgroundColor="@drawable/chip_color_toggle" />
+                            android:text="@string/dinner" />
 
                     </com.google.android.material.chip.ChipGroup>
 
@@ -414,7 +358,6 @@
                         android:id="@+id/menuItemsList"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="8dp"
                         android:clipChildren="false"
                         android:clipToPadding="false"
                         app:layout_constraintBottom_toBottomOf="parent"

--- a/Density/app/src/main/res/layout/facility_info_page.xml
+++ b/Density/app/src/main/res/layout/facility_info_page.xml
@@ -214,13 +214,14 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_margin="16dp"
+                app:layout_constraintBottom_toTopOf="@id/menuCard"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/dayChips">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"
+                    android:layout_height="wrap_content"
                     android:clipChildren="false"
                     android:clipToPadding="false"
                     android:orientation="vertical"
@@ -287,8 +288,7 @@
                 android:layout_marginBottom="16dp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/historicalDataCard">
+                app:layout_constraintStart_toStartOf="parent">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
@@ -360,6 +360,7 @@
                         android:layout_height="wrap_content"
                         android:clipChildren="false"
                         android:clipToPadding="false"
+                        android:padding="8dp"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"

--- a/Density/app/src/main/res/layout/facility_info_page.xml
+++ b/Density/app/src/main/res/layout/facility_info_page.xml
@@ -71,7 +71,6 @@
                         android:layout_width="wrap_content"
                         android:layout_height="0dp"
                         android:gravity="end"
-                        android:text="Status"
                         android:textSize="14sp"
                         app:layout_constraintBottom_toBottomOf="@id/now_header"
                         app:layout_constraintEnd_toEndOf="parent"
@@ -286,6 +285,7 @@
                 android:layout_marginTop="16dp"
                 android:layout_marginEnd="16dp"
                 android:layout_marginBottom="16dp"
+                android:visibility="gone"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent">

--- a/Density/app/src/main/res/layout/facility_info_page.xml
+++ b/Density/app/src/main/res/layout/facility_info_page.xml
@@ -316,6 +316,7 @@
                 android:id="@+id/menuCard"
                 style="@style/MyCardView"
                 android:layout_width="0dp"
+                android:visibility="invisible"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"

--- a/Density/app/src/main/res/layout/menu_category_list_item.xml
+++ b/Density/app/src/main/res/layout/menu_category_list_item.xml
@@ -10,7 +10,6 @@
         android:text="Category Name"
         android:textSize="15sp"
         android:textStyle="bold"
-        android:layout_marginLeft="5dp"
         android:layout_marginTop="15dp"
         android:layout_marginBottom="15dp" />
 

--- a/Density/app/src/main/res/layout/menu_food_list_item.xml
+++ b/Density/app/src/main/res/layout/menu_food_list_item.xml
@@ -9,7 +9,6 @@
         android:layout_height="wrap_content"
         android:text="Food Name"
         android:textSize="12sp"
-        android:layout_marginLeft="5dp"
-        android:padding="5dp"/>
+        android:padding="8dp"/>
 
 </LinearLayout>

--- a/Density/app/src/main/res/values/colors.xml
+++ b/Density/app/src/main/res/values/colors.xml
@@ -12,4 +12,6 @@
     <color name="filler_boxes">#EDEDED</color>
 
     <color name="border">#dad7d7</color>
+
+    <color name="chip_background">#EFEFEF</color>
 </resources>

--- a/Density/app/src/main/res/values/strings.xml
+++ b/Density/app/src/main/res/values/strings.xml
@@ -37,11 +37,11 @@
 
     <string name="Su">Su</string>
     <string name="M">M</string>
-    <string name="Tu">Tu</string>
+    <string name="T">T</string>
     <string name="W">W</string>
     <string name="Th">Th</string>
     <string name="F">F</string>
-    <string name="Sa">Sa</string>
+    <string name="S">Sa</string>
 
     <string name="menu">Menu</string>
     <string name="breakfast">Breakfast</string>

--- a/Density/app/src/main/res/values/styles.xml
+++ b/Density/app/src/main/res/values/styles.xml
@@ -20,6 +20,19 @@
         <item name="cardCornerRadius">8dp</item>
     </style>
 
+    <style name="BaseChipStyle" parent="Widget.MaterialComponents.Chip.Choice">
+        <item name="android:textAlignment">center</item>
+        <item name="android:textColor">@android:color/black</item>
+        <item name="android:textSize">@dimen/chip_text_size</item>
+        <item name="chipBackgroundColor">@drawable/chip_color_toggle</item>
+        <item name="chipStrokeWidth">0dp</item>
+    </style>
+
+    <style name="OutlineChipStyle" parent="BaseChipStyle">
+        <item name="chipStrokeWidth">2dp</item>
+        <item name="chipStrokeColor">@color/chip_background</item>
+    </style>
+
     <style name="DTI.Headline6" parent="TextAppearance.MaterialComponents.Headline6">
         <item name="android:textSize">16sp</item>
     </style>


### PR DESCRIPTION
### Summary <!-- Required -->

This PR works towards implementing changes to chips on the `FacilityInfoPage` that we discussed in our meeting.

- Moved Day Chips above the Historical Data Card
- Enabled Day Chips to change menu on facility info page
- Made Menu Card only show when there is a menu to show
- Removed some of the hard-coded string values for days and replaced with resource strings
- Added styles for chips (`BaseChipStyle` and `OutlineChipStyle`)
- Fixed spacing and code throughout facility info page

### Test Plan <!-- Required -->
- Use Postman to determine what menu should be for future day in a week and check that the app is showing the correct menu when the day is switched using the day chips.
- Try opening Cafe Jennie Facility Info page and ensure that the Menu Card does not show at all 

<!-- Provide screenshots or point out the additional unit tests -->

![88064002_128314965287832_2745381934992457728_n](https://user-images.githubusercontent.com/8313666/75633010-78b97780-5bcf-11ea-92f2-30619c92961a.png)
![87881251_535560843738117_3658431457442922496_n](https://user-images.githubusercontent.com/8313666/75633012-7a833b00-5bcf-11ea-81d5-a40eb49e5872.png)
