### PR TITLE
Added OperatingHoursClass and added conditional cases for open/closed text shown on toolbar

### DIFF
--- a/Density/app/src/main/java/org/cornelldti/density/density/data/OperatingHoursClass.kt
+++ b/Density/app/src/main/java/org/cornelldti/density/density/data/OperatingHoursClass.kt
@@ -1,0 +1,10 @@
+package org.cornelldti.density.density.data
+
+class OperatingHoursClass(todayOperatingHours: List<Pair<Long, Long>>, tomorrowFirstOpHours: Pair<Long, Long>) {
+    lateinit var todayOperatingHours: List<Pair<Long, Long>>
+    lateinit var tomorrowFirstOpHours: Pair<Long, Long>
+    init {
+        this.todayOperatingHours = todayOperatingHours
+        this.tomorrowFirstOpHours = tomorrowFirstOpHours
+    }
+}

--- a/Density/app/src/main/java/org/cornelldti/density/density/data/OperatingHoursClass.kt
+++ b/Density/app/src/main/java/org/cornelldti/density/density/data/OperatingHoursClass.kt
@@ -1,10 +1,3 @@
 package org.cornelldti.density.density.data
 
-class OperatingHoursClass(todayOperatingHours: List<Pair<Long, Long>>, tomorrowFirstOpHours: Pair<Long, Long>) {
-    lateinit var todayOperatingHours: List<Pair<Long, Long>>
-    lateinit var tomorrowFirstOpHours: Pair<Long, Long>
-    init {
-        this.todayOperatingHours = todayOperatingHours
-        this.tomorrowFirstOpHours = tomorrowFirstOpHours
-    }
-}
+data class OperatingHoursClass(val todayOperatingHours: List<Pair<Long, Long>>, val tomorrowFirstOpHours: Pair<Long, Long>)

--- a/Density/app/src/main/java/org/cornelldti/density/density/network/API.kt
+++ b/Density/app/src/main/java/org/cornelldti/density/density/network/API.kt
@@ -9,6 +9,7 @@ import com.android.volley.toolbox.JsonArrayRequest
 import com.android.volley.toolbox.Volley
 import org.cornelldti.density.density.data.FacilityClass
 import org.cornelldti.density.density.data.MenuClass
+import org.cornelldti.density.density.data.OperatingHoursClass
 import org.json.JSONArray
 import org.json.JSONException
 
@@ -166,7 +167,7 @@ class API(context: Context) {
     /**
      * This function applies the onResponse functions passed in as params on the response of the api request.
      */
-    fun facilityHours(facilityId: String, startDate: String, endDate: String, facilityHoursTimeStampsOnResponse: (List<Pair<Long, Long>>) -> Unit,
+    fun facilityHours(facilityId: String, startDate: String, endDate: String, facilityHoursTimeStampsOnResponse: (OperatingHoursClass) -> Unit,
                       facilityHoursStringsOnResponse: (List<String>) -> Unit) {
         val facilityHoursRequest = getRequest(
                 url = "$OPERATING_HOURS_ENDPOINT?id=$facilityId&startDate=$startDate&endDate=$endDate",

--- a/Density/app/src/main/java/org/cornelldti/density/density/network/JsonParser.kt
+++ b/Density/app/src/main/java/org/cornelldti/density/density/network/JsonParser.kt
@@ -115,30 +115,30 @@ object JsonParser {
      * This is returned in format of a list of pairs of start and end timestamps.
      * Sample Response: [(1000000, 1200000), (1300000, 1500000), (1600000, 1800000)]
      */
-    fun parseOperatingHoursToTimestampList(jsonArray: JSONArray): List<Pair<Long, Long>> {
-        val operatingHours = arrayListOf<Pair<Long, Long>>()
+    fun parseOperatingHoursToTimestampList(jsonArray: JSONArray): OperatingHoursClass {
+        val todayOperatingHours = arrayListOf<Pair<Long, Long>>()
+        var tomorrowFirstOpHours = Pair(-1L, -1L)
         try {
             val hours = jsonArray.getJSONObject(0).getJSONArray("hours")
             val currDate = FluxUtil.getCurrentDate()
-            var firstSlotNextDayAdded = false
             for (i in 0 until hours.length()) {
                 if (hours.getJSONObject(i).getString("date") == currDate) {
                     val segment = hours.getJSONObject(i).getJSONObject("dailyHours")
                     val start = segment.getLong("startTimestamp")
                     val end = segment.getLong("endTimestamp")
-                    operatingHours.add(Pair(start, end))
-                } else if (!firstSlotNextDayAdded) {
+                    todayOperatingHours.add(Pair(start, end))
+                } else {
                     val segment = hours.getJSONObject(i).getJSONObject("dailyHours")
                     val start = segment.getLong("startTimestamp")
                     val end = segment.getLong("endTimestamp")
-                    operatingHours.add(Pair(start, end))
+                    tomorrowFirstOpHours = Pair(start, end)
                     break
                 }
             }
         } catch (e: JSONException) {
             e.printStackTrace()
         }
-        return operatingHours
+        return OperatingHoursClass(todayOperatingHours, tomorrowFirstOpHours)
     }
 
     fun parseHistorical(jsonArray: JSONArray, day: String): List<Double> {


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request involved adding an OperatingHoursClass to handle holding both a list of timestamps for opening time slots in the current day and the first opening hour time slot for the next day. This way, if a Facility is closed for the day, then the function setOpenOrClosedToolbar() checks to see the first operating hour time slot of the next day to tell the user when the dining hall will open next.

### Test Plan <!-- Required -->

This pull request can be tested by navigating through different facility's info pages. When doing this, look at the operating hours and see if the open closed statement printed in the toolbar is accurate. Certain edge cases to look for could be in the case that the dining hall is closed for the day and will open tomorrow. In this case make sure that the first opening time for tomorrow is printed (for example "Closed, opens at 9am"). Also check the case that there is no operating hours tomorrow, in which case it should just say "Closed".