### PR TITLE
Use tabs instead of chips for selecting menus

### DIFF
--- a/Density/app/src/main/java/org/cornelldti/density/density/facilitydetail/FacilityInfoPage.kt
+++ b/Density/app/src/main/java/org/cornelldti/density/density/facilitydetail/FacilityInfoPage.kt
@@ -21,6 +21,7 @@ import com.github.mikephil.charting.components.XAxis
 import com.github.mikephil.charting.data.BarData
 import com.github.mikephil.charting.data.BarEntry
 import com.github.mikephil.charting.formatter.IndexAxisValueFormatter
+import com.google.android.material.tabs.TabLayout
 import kotlinx.android.synthetic.main.facility_info_page.*
 import org.cornelldti.density.density.BaseActivity
 import org.cornelldti.density.density.DensityApplication
@@ -38,7 +39,7 @@ import kotlin.collections.ArrayList
 
 class FacilityInfoPage : BaseActivity() {
 
-    private var selectedDay: String? = null
+    private var selectedDay: String = FluxUtil.dayString
 
     private val months = listOf("January", "February", "March", "April", "May", "June",
             "July", "August", "September", "October", "November", "December")
@@ -47,6 +48,16 @@ class FacilityInfoPage : BaseActivity() {
 
     private lateinit var feedback: TextView
 
+    /**
+     * Ordered list of available meals (e.g., ["breakfast", "lunch", "dinner"]
+     */
+    private var availableMenus: List<String> = listOf()
+
+    /**
+     * Current menu of the day
+     */
+    private var currentMenu: MenuClass? = null
+
     private lateinit var menuItemList: RecyclerView
     private lateinit var menuItemListViewAdapter: RecyclerView.Adapter<*>
     private lateinit var menuItemListViewManager: RecyclerView.LayoutManager
@@ -54,7 +65,6 @@ class FacilityInfoPage : BaseActivity() {
     private var facilityClass: FacilityClass? = null
 
     private var wasCheckedDay: Int = -1
-    private var wasCheckedMenu: Int = -1
 
     private var opHoursStrings: List<String> = ArrayList() // KEEPS TRACK OF OPERATING HOURS STRINGS FOR FACILITY
     // USED FOR DISPLAYING OPERATING HOURS OF FACILITY AT SELECTED DAY
@@ -89,6 +99,7 @@ class FacilityInfoPage : BaseActivity() {
         setDayChipsDate()
         setDayChipOnClickListener()
         setDataLastUpdated()
+        setOnTabSelectedListener()
     }
 
     private fun setDataLastUpdated() {
@@ -137,44 +148,26 @@ class FacilityInfoPage : BaseActivity() {
     private fun setDayChipOnClickListener() {
         dayChips.setOnCheckedChangeListener { _, checkedId ->
             setDay(checkedId)
-            setDayMenu(checkedId)
         }
     }
 
     private fun setDay(checkedId: Int) {
-        var day = ""
-        when (checkedId) {
-            R.id.sun -> day = getString(R.string.SUN)
-            R.id.mon -> day = getString(R.string.MON)
-            R.id.tue -> day = getString(R.string.TUE)
-            R.id.wed -> day = getString(R.string.WED)
-            R.id.thu -> day = getString(R.string.THU)
-            R.id.fri -> day = getString(R.string.FRI)
-            R.id.sat -> day = getString(R.string.SAT)
-            -1 -> dayChips.check(wasCheckedDay)
+        val day = when (checkedId) {
+            R.id.sun -> getString(R.string.SUN)
+            R.id.mon -> getString(R.string.MON)
+            R.id.tue -> getString(R.string.TUE)
+            R.id.wed -> getString(R.string.WED)
+            R.id.thu -> getString(R.string.THU)
+            R.id.fri -> getString(R.string.FRI)
+            R.id.sat -> getString(R.string.SAT)
+            else -> FluxUtil.dayString
         }
         if (checkedId != -1 && wasCheckedDay != checkedId) {
             wasCheckedDay = checkedId
             selectedDay = day
-            val daysDifference = FluxUtil.getDayDifference(FluxUtil.dayString, selectedDay!!)
-            updateOperatingHoursOfSelectedDay(FluxUtil.getDateDaysAfter(daysDifference))
+            val daysDifference = FluxUtil.getDayDifference(FluxUtil.dayString, selectedDay)
+            fetchMenuJSON(day = FluxUtil.getDateStringDaysAfter(daysDifference), facilityId = facilityClass!!.id)
         }
-    }
-
-    private fun setDayMenu(checkedId: Int) {
-        var selectedDay = FluxUtil.dayString
-        when (checkedId) {
-            R.id.sun -> selectedDay = getString(R.string.SUN)
-            R.id.mon -> selectedDay = getString(R.string.MON)
-            R.id.tue -> selectedDay = getString(R.string.TUE)
-            R.id.wed -> selectedDay = getString(R.string.WED)
-            R.id.thu -> selectedDay = getString(R.string.THU)
-            R.id.fri -> selectedDay = getString(R.string.FRI)
-            R.id.sat -> selectedDay = getString(R.string.SAT)
-            -1 -> FluxUtil.dayString
-        }
-        val daysDifference = FluxUtil.getDayDifference(FluxUtil.dayString, selectedDay)
-        fetchMenuJSON(day = FluxUtil.getDateStringDaysAfter(daysDifference), facilityId = facilityClass!!.id)
     }
 
     private fun setupBarChart() {
@@ -282,30 +275,8 @@ class FacilityInfoPage : BaseActivity() {
                     opHoursTimestamps = hoursTimeStampsList
                     setOpenOrClosedOnToolbar()
                 },
-                facilityHoursStringsOnResponse = { hoursStringsList ->
-                    opHoursStrings = hoursStringsList
-                    setOperatingHoursText(day = selectedDay!!, date = date)
-                    fetchHistoricalJSON(day = selectedDay!!, facilityId = facilityClass!!.id)
-                    fetchMenuJSON(day = FluxUtil.getCurrentDate(), facilityId = facilityClass!!.id)
-                })
-    }
-
-    /**
-     * This function is meant to only update the facility hours under the historical data chart
-     * for the selected day, and does not affect the facility hours used to check if the place is open. Thus, here
-     * facilityHoursTimeStampsOnResponse is not defined.
-     */
-    private fun updateOperatingHoursOfSelectedDay(date: Date) {
-        val dateString = FluxUtil.convertDateObjectToString(date)
-        api.facilityHours(facilityId = facilityClass!!.id, startDate = dateString,
-                endDate = dateString,
-                facilityHoursTimeStampsOnResponse = {
-                    // Isn't Defined!
-                },
-                facilityHoursStringsOnResponse = { hoursStringsList ->
-                    opHoursStrings = hoursStringsList
-                    setOperatingHoursText(day = selectedDay!!, date = date)
-                    fetchHistoricalJSON(day = selectedDay!!, facilityId = facilityClass!!.id)
+                facilityHoursStringsOnResponse = {
+                    fetchMenuJSON(FluxUtil.getCurrentDate(), facilityClass!!.id)
                 })
     }
 
@@ -385,7 +356,7 @@ class FacilityInfoPage : BaseActivity() {
     private fun setToday(dayString: String) {
         selectedDay = dayString
 
-        val dayChipList = arrayListOf<RadioButton>(sun, mon, tue, wed, thu, fri, sat);
+        val dayChipList = arrayListOf<RadioButton>(sun, mon, tue, wed, thu, fri, sat)
         dayChips.removeAllViews()
 
         val todayInt = FluxUtil.dayInt
@@ -396,40 +367,9 @@ class FacilityInfoPage : BaseActivity() {
         wasCheckedDay = dayChips.checkedRadioButtonId
     }
 
-    /**
-     * This function sets the operating hours text under the historical data chart
-     * @param day The day for which the operating hours is set
-     */
-    private fun setOperatingHoursText(day: String, date: Date) {
-        Log.d("SET", "OPERATING")
-        val hourTitle = FluxUtil.dayFullString(day)
-        todayHours.text = hourTitle
-        val todayDateFormat = SimpleDateFormat("MMMMM dd", Locale.US)
-        todayDate.text = todayDateFormat.format(date)
-        val todayDayDateFormat = SimpleDateFormat("EEE, MMM dd", Locale.US)
-        todayDayDate.text = todayDayDateFormat.format(date)
-        if (opHoursStrings.isEmpty()) facilityHours.text = getString(R.string.no_operating_hours)
-        else facilityHours.text = ""
-        for (operatingSegment in opHoursStrings) {
-            val allHours = facilityHours.text.toString() + operatingSegment + if (opHoursStrings.indexOf(operatingSegment) == opHoursStrings.size - 1) "" else "\n"
-            facilityHours.text = allHours
-        }
-    }
-
     override fun updateUI() {
         Log.d("updatedFPUI", "updating")
         fetchOperatingHours(date = FluxUtil.getDateObject(selectedDay!!)) // TODO FIX!! ON REFRESH!!
-    }
-
-    private fun fetchHistoricalJSON(day: String, facilityId: String) {
-        api.fetchHistoricalJSON(
-                day = day,
-                facilityId = facilityId,
-                fetchHistoricalJSONOnResponse = { historicalDensities ->
-                    densities = historicalDensities
-                    setupBarChart()
-                }
-        )
     }
 
     private fun fetchMenuJSON(day: String, facilityId: String) {
@@ -437,76 +377,96 @@ class FacilityInfoPage : BaseActivity() {
                 day = day,
                 facilityId = facilityId
         ) { menu ->
+            // set the current menu to the fetched menu
+            currentMenu = menu
+
+            // once loaded, hide the loader
             menuProgressBar.isGone = true
+
+            val dayAvailableMenus = mutableListOf<String>()
+            val dayAvailableMenuTabs = mutableListOf<TabLayout.Tab>()
+
+            if (menu?.breakfastItems?.size != 0) {
+                dayAvailableMenuTabs.add(menuTabs.newTab().setText(R.string.breakfast))
+                dayAvailableMenus.add("breakfast")
+            }
+            if (menu?.brunchItems?.size != 0) {
+                dayAvailableMenuTabs.add(menuTabs.newTab().setText(R.string.brunch))
+                dayAvailableMenus.add("brunch")
+            }
+            if (menu?.lunchItems?.size != 0) {
+                dayAvailableMenuTabs.add(menuTabs.newTab().setText(R.string.lunch))
+                dayAvailableMenus.add("lunch")
+            }
+            if (menu?.dinnerItems?.size != 0) {
+                dayAvailableMenuTabs.add(menuTabs.newTab().setText(R.string.dinner))
+                dayAvailableMenus.add("dinner")
+            }
+
             if (menu?.breakfastItems?.size == 0
                     && menu.brunchItems.isEmpty()
                     && menu.lunchItems.isEmpty()
                     && menu.dinnerItems.isEmpty()) {
-//                menu_header.isGone = true
-//                menuCard.isGone = true
-                menuChips.isGone = true
+                menuTabs.isGone = true
                 defaultMenuText.isVisible = true
+                showMenu(menu, "")
             } else {
-                menu_header.isVisible = true
-                menuChips.isVisible = true
-                menuCard.isVisible = true
+                menuTabs.isVisible = true
                 defaultMenuText.isGone = true
-                breakfast.isGone = !(menu?.breakfastItems?.isNotEmpty() ?: false)
-                brunch.isGone = !(menu?.brunchItems?.isNotEmpty() ?: false)
-                lunch.isGone = !(menu?.lunchItems?.isNotEmpty() ?: false)
-                dinner.isGone = !(menu?.dinnerItems?.isNotEmpty() ?: false)
-                wasCheckedMenu = firstVisibleChipId(menu)
-                showMenu(menu, wasCheckedMenu)
-                menuChips.setOnCheckedChangeListener { _, checkedId -> showMenu(menu, checkedId) }
+
+                var lastSelectedMeal = ""
+                if (availableMenus.isNotEmpty())
+                    lastSelectedMeal = availableMenus[menuTabs.selectedTabPosition]
+
+                availableMenus = dayAvailableMenus
+                menuTabs.removeAllTabs()
+                for (tab in dayAvailableMenuTabs)
+                    menuTabs.addTab(tab)
+
+                var selectedMealIndex = availableMenus.indexOf(lastSelectedMeal)
+
+                if (selectedMealIndex == -1) {
+                    menuTabs.selectTab(menuTabs.getTabAt(0))
+                    selectedMealIndex = 0
+                } else {
+                    menuTabs.selectTab(menuTabs.getTabAt(selectedMealIndex))
+                }
+                showMenu(menu, availableMenus[selectedMealIndex])
             }
         }
     }
 
-    /**
-     * Helper function that selects first visible chip and returns its ID
-     */
-    private fun firstVisibleChipId(menu: MenuClass?): Int {
-        if (menu != null) {
-            when {
-                menu.breakfastItems.isNotEmpty() -> {
-                    breakfast.isChecked = true
-                    return R.id.breakfast
-                }
-                menu.brunchItems.isNotEmpty() -> {
-                    brunch.isChecked = true
-                    return R.id.brunch
-                }
-                menu.lunchItems.isNotEmpty() -> {
-                    lunch.isChecked = true
-                    return R.id.lunch
-                }
-                menu.dinnerItems.isNotEmpty() -> {
-                    dinner.isChecked = true
-                    return R.id.dinner
-                }
-                else -> {
-                    return -1
+    private fun setOnTabSelectedListener() {
+        val listener = object : TabLayout.OnTabSelectedListener {
+
+            override fun onTabSelected(tab: TabLayout.Tab?) {
+                // Handle tab select
+                if (availableMenus.isNotEmpty()) {
+                    showMenu(currentMenu, availableMenus[menuTabs.selectedTabPosition])
                 }
             }
-        } else {
-            return -1
+
+            override fun onTabReselected(tab: TabLayout.Tab?) {
+                // Handle tab reselect
+            }
+
+            override fun onTabUnselected(tab: TabLayout.Tab?) {
+                // Handle tab unselect
+            }
         }
+
+        menuTabs.addOnTabSelectedListener(listener)
     }
 
-
-    private fun showMenu(menu: MenuClass?, mealOfDay: Int) {
+    private fun showMenu(menu: MenuClass?, mealOfDay: String) {
         if (menu != null) {
             menuItemListViewManager = LinearLayoutManager(this)
-            when (mealOfDay) {
-                R.id.breakfast -> menuItemListViewAdapter = MenuListAdapter(menu.breakfastItems, this)
-                R.id.brunch -> menuItemListViewAdapter = MenuListAdapter(menu.brunchItems, this)
-                R.id.lunch -> menuItemListViewAdapter = MenuListAdapter(menu.lunchItems, this)
-                R.id.dinner -> menuItemListViewAdapter = MenuListAdapter(menu.dinnerItems, this)
-                -1 -> if (wasCheckedMenu != -1) menuChips.check(wasCheckedMenu)
-                else menuItemListViewAdapter = MenuListAdapter(ArrayList(), this)
-            }
-            if (mealOfDay != -1 && wasCheckedMenu != mealOfDay) {
-                wasCheckedMenu = mealOfDay
+            menuItemListViewAdapter = when (mealOfDay) {
+                "breakfast" -> MenuListAdapter(menu.breakfastItems, this)
+                "brunch" -> MenuListAdapter(menu.brunchItems, this)
+                "lunch" -> MenuListAdapter(menu.lunchItems, this)
+                "dinner" -> MenuListAdapter(menu.dinnerItems, this)
+                else -> MenuListAdapter(listOf(), this)
             }
 
             menuItemList = findViewById<RecyclerView>(R.id.menuItemsList).apply {
@@ -517,7 +477,6 @@ class FacilityInfoPage : BaseActivity() {
                 layoutManager = menuItemListViewManager
 
                 adapter = menuItemListViewAdapter
-
             }
 
         } else {

--- a/Density/app/src/main/java/org/cornelldti/density/density/facilitydetail/FacilityInfoPage.kt
+++ b/Density/app/src/main/java/org/cornelldti/density/density/facilitydetail/FacilityInfoPage.kt
@@ -403,7 +403,7 @@ class FacilityInfoPage : BaseActivity() {
                 dayAvailableMenus.add("dinner")
             }
 
-            if (menu?.breakfastItems?.size == 0
+            if (menu?.breakfastItems?.isEmpty() == true
                     && menu.brunchItems.isEmpty()
                     && menu.lunchItems.isEmpty()
                     && menu.dinnerItems.isEmpty()) {
@@ -425,12 +425,9 @@ class FacilityInfoPage : BaseActivity() {
 
                 var selectedMealIndex = availableMenus.indexOf(lastSelectedMeal)
 
-                if (selectedMealIndex == -1) {
-                    menuTabs.selectTab(menuTabs.getTabAt(0))
+                if (selectedMealIndex == -1)
                     selectedMealIndex = 0
-                } else {
-                    menuTabs.selectTab(menuTabs.getTabAt(selectedMealIndex))
-                }
+                menuTabs.selectTab(menuTabs.getTabAt(selectedMealIndex))
                 showMenu(menu, availableMenus[selectedMealIndex])
             }
         }

--- a/Density/app/src/main/res/drawable/bottom_border.xml
+++ b/Density/app/src/main/res/drawable/bottom_border.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:left="-2dp"
+        android:right="-2dp"
+        android:top="-2dp">
+        <shape android:shape="rectangle">
+            <stroke
+                android:width="1dp"
+                android:color="@color/border" />
+        </shape>
+    </item>
+</layer-list>

--- a/Density/app/src/main/res/layout/facility_info_page.xml
+++ b/Density/app/src/main/res/layout/facility_info_page.xml
@@ -223,20 +223,6 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/dayChips" />
 
-            <com.google.android.material.tabs.TabLayout
-                android:id="@+id/menuTabs"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:visibility="gone"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/menu_header"
-                app:tabIndicatorColor="@color/very_empty"
-                app:tabSelectedTextColor="@color/very_empty"
-                app:tabTextColor="@color/dark_grey">
-
-            </com.google.android.material.tabs.TabLayout>
-
             <androidx.cardview.widget.CardView
                 android:id="@+id/menuCard"
                 style="@style/MyCardView"
@@ -247,13 +233,24 @@
                 android:focusable="false"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/menuTabs">
+                app:layout_constraintTop_toBottomOf="@id/menu_header">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:orientation="vertical"
-                    android:padding="8dp">
+                    android:layout_height="match_parent">
+
+                    <com.google.android.material.tabs.TabLayout
+                        android:id="@+id/menuTabs"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:visibility="gone"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:tabIndicatorColor="@color/very_empty"
+                        app:tabSelectedTextColor="@color/very_empty"
+                        app:tabTextColor="@color/dark_grey"
+                        android:background="@drawable/bottom_border" />
 
                     <androidx.recyclerview.widget.RecyclerView
                         android:id="@+id/menuItemsList"
@@ -261,13 +258,13 @@
                         android:layout_height="wrap_content"
                         android:clipChildren="false"
                         android:clipToPadding="false"
-                        android:paddingStart="8dp"
-                        android:paddingEnd="8dp"
-                        android:paddingBottom="8dp"
+                        android:paddingStart="16dp"
+                        android:paddingEnd="16dp"
+                        android:paddingBottom="16dp"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent">
+                        app:layout_constraintTop_toBottomOf="@id/menuTabs">
 
                     </androidx.recyclerview.widget.RecyclerView>
 
@@ -275,7 +272,7 @@
                         android:id="@+id/defaultMenuText"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:padding="8dp"
+                        android:padding="16dp"
                         android:text="@string/menu_default_text"
                         android:textColor="@color/dark_grey"
                         android:textSize="14sp"
@@ -288,6 +285,7 @@
                         android:id="@+id/menuProgressBar"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:padding="16dp"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"

--- a/Density/app/src/main/res/layout/facility_info_page.xml
+++ b/Density/app/src/main/res/layout/facility_info_page.xml
@@ -212,55 +212,55 @@
                     android:textAlignment="center" />
             </RadioGroup>
 
-            <TextView
-                android:id="@+id/operatingHoursHeader"
-                style="@style/DTI.CardHeader"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="16dp"
-                android:text="Operating Hours"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/dayChips" />
+            <!--            <TextView-->
+            <!--                android:id="@+id/operatingHoursHeader"-->
+            <!--                style="@style/DTI.CardHeader"-->
+            <!--                android:layout_width="wrap_content"-->
+            <!--                android:layout_height="wrap_content"-->
+            <!--                android:layout_marginStart="8dp"-->
+            <!--                android:layout_marginTop="16dp"-->
+            <!--                android:text="Operating Hours"-->
+            <!--                app:layout_constraintStart_toStartOf="parent"-->
+            <!--                app:layout_constraintTop_toBottomOf="@id/dayChips" />-->
 
-            <androidx.cardview.widget.CardView
-                android:id="@+id/operatingHoursCard"
-                style="@style/MyCardView"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/operatingHoursHeader">
+            <!--            <androidx.cardview.widget.CardView-->
+            <!--                android:id="@+id/operatingHoursCard"-->
+            <!--                style="@style/MyCardView"-->
+            <!--                android:layout_width="0dp"-->
+            <!--                android:layout_height="wrap_content"-->
+            <!--                android:layout_marginTop="8dp"-->
+            <!--                app:layout_constraintEnd_toEndOf="parent"-->
+            <!--                app:layout_constraintStart_toStartOf="parent"-->
+            <!--                app:layout_constraintTop_toBottomOf="@id/operatingHoursHeader">-->
 
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:paddingStart="16dp"
-                    android:paddingEnd="16dp"
-                    android:paddingBottom="16dp">
+            <!--                <LinearLayout-->
+            <!--                    android:layout_width="wrap_content"-->
+            <!--                    android:layout_height="wrap_content"-->
+            <!--                    android:orientation="vertical"-->
+            <!--                    android:paddingStart="16dp"-->
+            <!--                    android:paddingEnd="16dp"-->
+            <!--                    android:paddingBottom="16dp">-->
 
-                    <TextView
-                        android:id="@+id/todayDayDate"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="15dp"
-                        android:textColor="@android:color/black"
-                        android:textSize="17sp" />
+            <!--                    <TextView-->
+            <!--                        android:id="@+id/todayDayDate"-->
+            <!--                        android:layout_width="match_parent"-->
+            <!--                        android:layout_height="wrap_content"-->
+            <!--                        android:layout_marginTop="15dp"-->
+            <!--                        android:textColor="@android:color/black"-->
+            <!--                        android:textSize="17sp" />-->
 
-                    <TextView
-                        android:id="@+id/facilityHours"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="2dp"
-                        android:lineSpacingExtra="2dp"
-                        android:textColor="@color/dark_grey"
-                        android:textSize="14sp" />
-                </LinearLayout>
+            <!--                    <TextView-->
+            <!--                        android:id="@+id/facilityHours"-->
+            <!--                        android:layout_width="match_parent"-->
+            <!--                        android:layout_height="wrap_content"-->
+            <!--                        android:layout_marginTop="2dp"-->
+            <!--                        android:lineSpacingExtra="2dp"-->
+            <!--                        android:textColor="@color/dark_grey"-->
+            <!--                        android:textSize="14sp" />-->
+            <!--                </LinearLayout>-->
 
 
-            </androidx.cardview.widget.CardView>
+            <!--            </androidx.cardview.widget.CardView>-->
 
             <TextView
                 android:id="@+id/menu_header"
@@ -271,50 +271,64 @@
                 android:layout_marginTop="16dp"
                 android:text="@string/menu"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/operatingHoursCard" />
+                app:layout_constraintTop_toBottomOf="@id/dayChips" />
 
-            <com.google.android.material.chip.ChipGroup
-                android:id="@+id/menuChips"
-                android:layout_width="wrap_content"
+            <!--            <com.google.android.material.chip.ChipGroup-->
+            <!--                android:id="@+id/menuChips"-->
+            <!--                android:layout_width="wrap_content"-->
+            <!--                android:layout_height="wrap_content"-->
+            <!--                android:layout_marginStart="8dp"-->
+            <!--                android:layout_marginTop="8dp"-->
+            <!--                android:visibility="gone"-->
+            <!--                app:chipSpacingHorizontal="0dp"-->
+            <!--                app:layout_constraintStart_toStartOf="parent"-->
+            <!--                app:layout_constraintTop_toBottomOf="@id/menu_header"-->
+            <!--                app:singleLine="true"-->
+            <!--                app:singleSelection="true">-->
+
+            <!--                <com.google.android.material.chip.Chip-->
+            <!--                    android:id="@+id/breakfast"-->
+            <!--                    style="@style/BaseChipStyle"-->
+            <!--                    android:layout_width="wrap_content"-->
+            <!--                    android:layout_height="match_parent"-->
+            <!--                    android:text="@string/breakfast" />-->
+
+            <!--                <com.google.android.material.chip.Chip-->
+            <!--                    android:id="@+id/brunch"-->
+            <!--                    style="@style/BaseChipStyle"-->
+            <!--                    android:layout_width="wrap_content"-->
+            <!--                    android:layout_height="match_parent"-->
+            <!--                    android:text="@string/brunch" />-->
+
+            <!--                <com.google.android.material.chip.Chip-->
+            <!--                    android:id="@+id/lunch"-->
+            <!--                    style="@style/BaseChipStyle"-->
+            <!--                    android:layout_width="wrap_content"-->
+            <!--                    android:layout_height="match_parent"-->
+            <!--                    android:text="@string/lunch" />-->
+
+            <!--                <com.google.android.material.chip.Chip-->
+            <!--                    android:id="@+id/dinner"-->
+            <!--                    style="@style/BaseChipStyle"-->
+            <!--                    android:layout_width="wrap_content"-->
+            <!--                    android:layout_height="match_parent"-->
+            <!--                    android:text="@string/dinner" />-->
+
+            <!--            </com.google.android.material.chip.ChipGroup>-->
+
+            <com.google.android.material.tabs.TabLayout
+                android:id="@+id/menuTabs"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="8dp"
                 android:visibility="gone"
-                app:chipSpacingHorizontal="0dp"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/menu_header"
-                app:singleLine="true"
-                app:singleSelection="true">
+                app:tabIndicatorColor="@color/very_empty"
+                app:tabSelectedTextColor="@color/very_empty"
+                app:tabTextColor="@color/dark_grey">
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/breakfast"
-                    style="@style/BaseChipStyle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:text="@string/breakfast" />
-
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/brunch"
-                    style="@style/BaseChipStyle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:text="@string/brunch" />
-
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/lunch"
-                    style="@style/BaseChipStyle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:text="@string/lunch" />
-
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/dinner"
-                    style="@style/BaseChipStyle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:text="@string/dinner" />
-
-            </com.google.android.material.chip.ChipGroup>
+            </com.google.android.material.tabs.TabLayout>
 
             <androidx.cardview.widget.CardView
                 android:id="@+id/menuCard"
@@ -326,7 +340,7 @@
                 android:focusable="false"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/menuChips">
+                app:layout_constraintTop_toBottomOf="@id/menuTabs">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
@@ -354,10 +368,10 @@
                         android:id="@+id/defaultMenuText"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:padding="8dp"
                         android:text="@string/menu_default_text"
                         android:textColor="@color/dark_grey"
                         android:textSize="14sp"
-                        android:padding="8dp"
                         android:visibility="gone"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintStart_toStartOf="parent"

--- a/Density/app/src/main/res/layout/facility_info_page.xml
+++ b/Density/app/src/main/res/layout/facility_info_page.xml
@@ -212,56 +212,6 @@
                     android:textAlignment="center" />
             </RadioGroup>
 
-            <!--            <TextView-->
-            <!--                android:id="@+id/operatingHoursHeader"-->
-            <!--                style="@style/DTI.CardHeader"-->
-            <!--                android:layout_width="wrap_content"-->
-            <!--                android:layout_height="wrap_content"-->
-            <!--                android:layout_marginStart="8dp"-->
-            <!--                android:layout_marginTop="16dp"-->
-            <!--                android:text="Operating Hours"-->
-            <!--                app:layout_constraintStart_toStartOf="parent"-->
-            <!--                app:layout_constraintTop_toBottomOf="@id/dayChips" />-->
-
-            <!--            <androidx.cardview.widget.CardView-->
-            <!--                android:id="@+id/operatingHoursCard"-->
-            <!--                style="@style/MyCardView"-->
-            <!--                android:layout_width="0dp"-->
-            <!--                android:layout_height="wrap_content"-->
-            <!--                android:layout_marginTop="8dp"-->
-            <!--                app:layout_constraintEnd_toEndOf="parent"-->
-            <!--                app:layout_constraintStart_toStartOf="parent"-->
-            <!--                app:layout_constraintTop_toBottomOf="@id/operatingHoursHeader">-->
-
-            <!--                <LinearLayout-->
-            <!--                    android:layout_width="wrap_content"-->
-            <!--                    android:layout_height="wrap_content"-->
-            <!--                    android:orientation="vertical"-->
-            <!--                    android:paddingStart="16dp"-->
-            <!--                    android:paddingEnd="16dp"-->
-            <!--                    android:paddingBottom="16dp">-->
-
-            <!--                    <TextView-->
-            <!--                        android:id="@+id/todayDayDate"-->
-            <!--                        android:layout_width="match_parent"-->
-            <!--                        android:layout_height="wrap_content"-->
-            <!--                        android:layout_marginTop="15dp"-->
-            <!--                        android:textColor="@android:color/black"-->
-            <!--                        android:textSize="17sp" />-->
-
-            <!--                    <TextView-->
-            <!--                        android:id="@+id/facilityHours"-->
-            <!--                        android:layout_width="match_parent"-->
-            <!--                        android:layout_height="wrap_content"-->
-            <!--                        android:layout_marginTop="2dp"-->
-            <!--                        android:lineSpacingExtra="2dp"-->
-            <!--                        android:textColor="@color/dark_grey"-->
-            <!--                        android:textSize="14sp" />-->
-            <!--                </LinearLayout>-->
-
-
-            <!--            </androidx.cardview.widget.CardView>-->
-
             <TextView
                 android:id="@+id/menu_header"
                 style="@style/DTI.CardHeader"
@@ -272,49 +222,6 @@
                 android:text="@string/menu"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/dayChips" />
-
-            <!--            <com.google.android.material.chip.ChipGroup-->
-            <!--                android:id="@+id/menuChips"-->
-            <!--                android:layout_width="wrap_content"-->
-            <!--                android:layout_height="wrap_content"-->
-            <!--                android:layout_marginStart="8dp"-->
-            <!--                android:layout_marginTop="8dp"-->
-            <!--                android:visibility="gone"-->
-            <!--                app:chipSpacingHorizontal="0dp"-->
-            <!--                app:layout_constraintStart_toStartOf="parent"-->
-            <!--                app:layout_constraintTop_toBottomOf="@id/menu_header"-->
-            <!--                app:singleLine="true"-->
-            <!--                app:singleSelection="true">-->
-
-            <!--                <com.google.android.material.chip.Chip-->
-            <!--                    android:id="@+id/breakfast"-->
-            <!--                    style="@style/BaseChipStyle"-->
-            <!--                    android:layout_width="wrap_content"-->
-            <!--                    android:layout_height="match_parent"-->
-            <!--                    android:text="@string/breakfast" />-->
-
-            <!--                <com.google.android.material.chip.Chip-->
-            <!--                    android:id="@+id/brunch"-->
-            <!--                    style="@style/BaseChipStyle"-->
-            <!--                    android:layout_width="wrap_content"-->
-            <!--                    android:layout_height="match_parent"-->
-            <!--                    android:text="@string/brunch" />-->
-
-            <!--                <com.google.android.material.chip.Chip-->
-            <!--                    android:id="@+id/lunch"-->
-            <!--                    style="@style/BaseChipStyle"-->
-            <!--                    android:layout_width="wrap_content"-->
-            <!--                    android:layout_height="match_parent"-->
-            <!--                    android:text="@string/lunch" />-->
-
-            <!--                <com.google.android.material.chip.Chip-->
-            <!--                    android:id="@+id/dinner"-->
-            <!--                    style="@style/BaseChipStyle"-->
-            <!--                    android:layout_width="wrap_content"-->
-            <!--                    android:layout_height="match_parent"-->
-            <!--                    android:text="@string/dinner" />-->
-
-            <!--            </com.google.android.material.chip.ChipGroup>-->
 
             <com.google.android.material.tabs.TabLayout
                 android:id="@+id/menuTabs"
@@ -460,20 +367,6 @@
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/todayHours" />
-                    <!--                    app:layout_constraintBottom_toTopOf="@id/facilityHours"-->
-
-                    <!--                    <TextView-->
-                    <!--                        android:id="@+id/facilityHours"-->
-                    <!--                        android:layout_width="match_parent"-->
-                    <!--                        android:layout_height="wrap_content"-->
-                    <!--                        android:gravity="center"-->
-                    <!--                        android:paddingBottom="8dp"-->
-                    <!--                        android:textColor="@color/dark_grey"-->
-                    <!--                        android:textSize="14sp"-->
-                    <!--                        app:layout_constraintBottom_toBottomOf="parent"-->
-                    <!--                        app:layout_constraintEnd_toEndOf="parent"-->
-                    <!--                        app:layout_constraintStart_toStartOf="parent"-->
-                    <!--                        app:layout_constraintTop_toBottomOf="@id/todayDate" />-->
 
                 </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request updates our app to use tabs instead of chips for selecting the menus (matches Figma designs). It also cleans up some code for historical data and previous operating hours.

This does NOT include the open hours redesign yet, despite the branch's name.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
![Screenshot_Flux_20201004-124137](https://user-images.githubusercontent.com/11168401/95021519-6c067180-063f-11eb-9be8-6318b2301219.png)

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->
- need to update colors since it just uses green (like in the designs)
- need to add back operating hours with the new design
- if we decide to add back historical data, we will need to look through old commits
