### PR TITLE
Support different screen size

### DIFF
--- a/Density/app/build.gradle
+++ b/Density/app/build.gradle
@@ -43,25 +43,27 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    api 'com.google.android.material:material:1.1.0'
+    api 'com.google.android.material:material:1.2.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'com.github.PhilJay:MPAndroidChart:v3.0.3'
-    implementation 'com.google.android.material:material:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta7'
+    implementation 'com.google.android.material:material:1.2.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.2'
     implementation 'com.github.PhilJay:MPAndroidChart:v3.0.3'
-    implementation 'com.google.firebase:firebase-core:17.4.3'
-    implementation 'com.google.firebase:firebase-auth:19.3.1'
-    implementation 'com.google.gms:google-services:4.3.3'
+    implementation 'com.google.firebase:firebase-core:17.5.1'
+    implementation 'com.google.firebase:firebase-auth:19.4.0'
+    implementation 'com.google.gms:google-services:4.3.4'
     implementation 'com.google.android.gms:play-services-gcm:17.0.0'
-    implementation 'com.android.volley:volley:1.1.0'
+    implementation 'com.android.volley:volley:1.1.1'
     testImplementation 'junit:junit:4.13'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    implementation 'androidx.core:core-ktx:1.3.0'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    implementation 'androidx.core:core-ktx:1.3.2'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'com.intuit.sdp:sdp-android:1.0.6'
+    implementation 'com.intuit.ssp:ssp-android:1.0.6'
 }
 apply plugin: 'com.google.gms.google-services'
 repositories {

--- a/Density/app/build.gradle
+++ b/Density/app/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.72'
+    ext.kotlin_version = '1.4.10'
     repositories {
         jcenter()
         google()
@@ -43,13 +43,13 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    api 'com.google.android.material:material:1.2.1'
+    api 'com.google.android.material:material:1.1.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'com.github.PhilJay:MPAndroidChart:v3.0.3'
-    implementation 'com.google.android.material:material:1.2.1'
+    implementation 'com.google.android.material:material:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.2'
     implementation 'com.github.PhilJay:MPAndroidChart:v3.0.3'
     implementation 'com.google.firebase:firebase-core:17.5.1'

--- a/Density/app/build.gradle
+++ b/Density/app/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.4.10'
+    ext.kotlin_version = '1.3.72'
     repositories {
         jcenter()
         google()

--- a/Density/app/src/main/res/layout/facilities_activity.xml
+++ b/Density/app/src/main/res/layout/facilities_activity.xml
@@ -103,21 +103,21 @@
                     android:id="@+id/covidPolicyCard"
                     style="@style/MyCardView"
                     android:layout_width="fill_parent"
-                    android:layout_height="120dp"
-                    android:layout_marginStart="16dp"
-                    android:layout_marginTop="8dp"
-                    android:layout_marginEnd="16dp"
-                    android:layout_marginBottom="8dp">
+                    android:layout_height="@dimen/_100sdp"
+                    android:layout_marginStart="@dimen/_13sdp"
+                    android:layout_marginTop="@dimen/_6sdp"
+                    android:layout_marginEnd="@dimen/_13sdp"
+                    android:layout_marginBottom="@dimen/_6sdp">
 
                     <androidx.constraintlayout.widget.ConstraintLayout
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:background="?android:attr/selectableItemBackground"
-                        android:padding="16dp">
+                        android:padding="@dimen/_13sdp">
 
                         <ImageView
                             android:id="@+id/masks_required_img"
-                            android:layout_width="120dp"
+                            android:layout_width="@dimen/_100sdp"
                             android:layout_height="wrap_content"
                             android:src="@drawable/masks_required"
                             app:layout_constraintBottom_toBottomOf="parent"
@@ -128,10 +128,10 @@
                             android:id="@+id/faceCoveringText"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:layout_marginStart="25dp"
+                            android:layout_marginStart="@dimen/_11sdp"
                             android:text="@string/covid_policy"
                             android:textColor="#5C5C5C"
-                            android:textSize="14sp"
+                            android:textSize="@dimen/_11ssp"
                             android:textStyle="bold"
                             app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintStart_toEndOf="@id/masks_required_img"
@@ -146,8 +146,8 @@
                             android:onClick="openCovidPolicy"
                             android:text="@string/covid_policy_button"
                             android:textColor="@android:color/white"
-                            android:textSize="12sp"
-                            android:layout_marginTop="16dp"
+                            android:textSize="@dimen/_9ssp"
+                            android:layout_marginTop="@dimen/_13sdp"
                             app:layout_constraintStart_toStartOf="@id/faceCoveringText"
                             app:layout_constraintTop_toBottomOf="@+id/faceCoveringText"
                             app:layout_constraintBottom_toBottomOf="parent"/>

--- a/Density/app/src/main/res/layout/facility_info_page.xml
+++ b/Density/app/src/main/res/layout/facility_info_page.xml
@@ -86,7 +86,7 @@
                         android:contentDescription="@string/availability_icon"
                         android:paddingVertical="3dp"
                         android:src="@drawable/ic_baseline_accessibility_new_24"
-                        android:tint="@android:color/white"
+                        app:tint="@android:color/white"
                         app:layout_constraintBottom_toBottomOf="@+id/availability_num"
                         app:layout_constraintDimensionRatio="1:1"
                         app:layout_constraintEnd_toEndOf="parent"

--- a/Density/app/src/main/res/layout/failure_page.xml
+++ b/Density/app/src/main/res/layout/failure_page.xml
@@ -12,7 +12,7 @@
         android:paddingEnd="0dp"
         android:scaleType="centerCrop"
         android:src="@drawable/flux_logo"
-        android:tint="@color/border"
+        app:tint="@color/border"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ _Last updated **02/08/2019**_.
 ## Dependencies & Libraries
  * [MPAndroidChart](https://github.com/PhilJay/MPAndroidChart) - a 3rd party library that allows us to easily input data and generate various graphs and charts to visualize it. 
  * [Volley](https://developer.android.com/training/volley/) - an Android Library that allows us to make HTTP Requests in a more simplified and abstracted manner using library functions.
+  * [sdp](https://github.com/intuit/sdp) - an android library that provides a scalable size unit for densities.
+  * [ssp](https://github.com/intuit/ssp) - an android library that provides a scalable size unit for texts.
 ​
 ## External Documentation
 * [Backend API Documentation](https://campusdensity.docs.apiary.io/) - this is an external Apiary documenting the endpoints for our application.


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request fixes issue #58 and prevents new COVID design overflow on different screen sizes, and also updates some of the app dependencies. It adjusts the COVID CardView to smaller screen sizes by introducing sdp/ssp: an android library that provides a scalable size unit for densities & texts. The layout mapping to sdp units was done in reference to sw360dp values.
- sdp: [https://github.com/intuit/sdp](url)
- ssp: [https://github.com/intuit/ssp](url)
(I have no idea why these hyperlinks are broken, but just copy+paste on a new window and it works)

### Test Plan <!-- Required -->
I tested the scalable layout on 12 devices with different screen sizes, resolution, and viewport width.
- Screen size: 4.65 in - 6.9 in
- Resolution: 720x1280 - 1440x3200
- VIewport width: 360 - 480

Below are some screenshots.
- Galaxy Nexus (4.65'')
![galaxy_nexus](https://user-images.githubusercontent.com/49200001/97112440-b61cc900-16ba-11eb-97ef-5b901e29e28d.png)
- Galaxy S7 (5.1'')
![galaxy_s7](https://user-images.githubusercontent.com/49200001/97112482-f0866600-16ba-11eb-8cdb-351298d99196.png)
- Galaxy S10e (5.8'')
![galaxy_s10e](https://user-images.githubusercontent.com/49200001/97112498-072cbd00-16bb-11eb-952f-7f6210ba62f0.png)
- Galaxy S20 (6.2'')
![galaxy_s20](https://user-images.githubusercontent.com/49200001/97112511-16136f80-16bb-11eb-93c0-ae749e0fe4f4.png)
- Galaxy S20 Ultra (6.9'')
![galaxy_s20_ultra](https://user-images.githubusercontent.com/49200001/97112526-2297c800-16bb-11eb-96f3-8b3b3ae6e1a2.png)



