### PR TITLE
Better handling for empty menus and fix other minor bugs

### DIFF
--- a/Density/app/src/main/java/org/cornelldti/density/density/facilities/FacilitiesActivity.kt
+++ b/Density/app/src/main/java/org/cornelldti/density/density/facilities/FacilitiesActivity.kt
@@ -40,8 +40,8 @@ import kotlin.math.absoluteValue
 class FacilitiesActivity : BaseActivity() {
 
     private lateinit var spinner: ProgressBar
-    private lateinit var waitTimesMap: Map<String, Double>
 
+    private var waitTimesMap: Map<String, Double> = emptyMap()
     private var adapter: FacilitiesListAdapter? = null
     private var collapsingToolbarLayout: CollapsingToolbarLayout? = null
     private var appBarLayout: AppBarLayout? = null
@@ -293,7 +293,6 @@ class FacilitiesActivity : BaseActivity() {
                     adapter.setWaitTimesMap(map)
                 },
                 onError = { error ->
-                    waitTimesMap = emptyMap()
                     Log.d("ERROR", error.toString())
                 }
         )

--- a/Density/app/src/main/java/org/cornelldti/density/density/facilities/FacilitiesListAdapter.kt
+++ b/Density/app/src/main/java/org/cornelldti/density/density/facilities/FacilitiesListAdapter.kt
@@ -50,7 +50,9 @@ class FacilitiesListAdapter(data: List<FacilityClass>) : RecyclerView.Adapter<Fa
         }
 
         override fun onClick(v: View) {
-            clickListener!!.onItemClick(adapterPosition, v)
+            if(adapterPosition != -1) {
+                clickListener!!.onItemClick(adapterPosition, v)
+            }
         }
     }
 

--- a/Density/app/src/main/java/org/cornelldti/density/density/facilitydetail/FacilityInfoPage.kt
+++ b/Density/app/src/main/java/org/cornelldti/density/density/facilitydetail/FacilityInfoPage.kt
@@ -69,8 +69,6 @@ class FacilityInfoPage : BaseActivity() {
             receivedWait = b.get("waitTimes")
         }
 
-        densityChart.setNoDataText("")
-
         topBar.title = facilityClass!!.name
         topBar.setNavigationOnClickListener { onBackPressed() }
 

--- a/Density/app/src/main/java/org/cornelldti/density/density/facilitydetail/FacilityInfoPage.kt
+++ b/Density/app/src/main/java/org/cornelldti/density/density/facilitydetail/FacilityInfoPage.kt
@@ -27,7 +27,6 @@ import org.cornelldti.density.density.facilitydetail.feedback.FeedbackDialogFrag
 import org.cornelldti.density.density.util.FluxUtil
 import java.text.SimpleDateFormat
 import java.util.*
-import kotlin.collections.ArrayList
 
 /**
  * This class holds the detail page activity for each individual dining location.
@@ -50,7 +49,6 @@ class FacilityInfoPage : BaseActivity() {
     private var currentMenu: MenuClass? = null
     private var facilityClass: FacilityClass? = null
     private var wasCheckedDay: Int = -1
-    private var densities: List<Double> = ArrayList() // KEEPS TRACK OF HISTORICAL DENSITIES
     private var waitTimesValue: Int? = 0
     private var receivedWait: Any? = null
     private var selectedDay: String = FluxUtil.dayString
@@ -411,10 +409,22 @@ class FacilityInfoPage : BaseActivity() {
         if (menu != null) {
             menuItemListViewManager = LinearLayoutManager(this)
             menuItemListViewAdapter = when (mealOfDay) {
-                "breakfast" -> MenuListAdapter(menu.breakfastItems, this)
-                "brunch" -> MenuListAdapter(menu.brunchItems, this)
-                "lunch" -> MenuListAdapter(menu.lunchItems, this)
-                "dinner" -> MenuListAdapter(menu.dinnerItems, this)
+                "breakfast" -> {
+                    defaultMenuText.isVisible = menu.breakfastItems.isEmpty()
+                    MenuListAdapter(menu.breakfastItems, this)
+                }
+                "brunch" -> {
+                    defaultMenuText.isVisible = menu.brunchItems.isEmpty()
+                    MenuListAdapter(menu.brunchItems, this)
+                }
+                "lunch" -> {
+                    defaultMenuText.isVisible = menu.lunchItems.isEmpty()
+                    MenuListAdapter(menu.lunchItems, this)
+                }
+                "dinner" -> {
+                    defaultMenuText.isVisible = menu.dinnerItems.isEmpty()
+                    MenuListAdapter(menu.dinnerItems, this)
+                }
                 else -> MenuListAdapter(listOf(), this)
             }
 
@@ -433,7 +443,7 @@ class FacilityInfoPage : BaseActivity() {
                 menuHours.text = menu.operatingHours[availableMenus.indexOf(mealOfDay)]
                 clock_image.visibility = View.VISIBLE
             } else {
-                menuHours.text = ""
+                menuHours.visibility = View.GONE
                 clock_image.visibility = View.GONE
             }
 

--- a/Density/app/src/main/res/layout/facility_card_layout.xml
+++ b/Density/app/src/main/res/layout/facility_card_layout.xml
@@ -41,8 +41,10 @@
             android:layout_height="wrap_content"
             android:text="@string/facility_wait_time"
             android:textColor="@color/dark_grey"
+            android:textSize="@dimen/_11ssp"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@id/facility_name" />
+            app:layout_constraintTop_toTopOf="@id/facility_name"
+            app:layout_constraintBottom_toBottomOf="@id/facility_name"/>
 
 
         <ImageView

--- a/Density/app/src/main/res/layout/facility_info_page.xml
+++ b/Density/app/src/main/res/layout/facility_info_page.xml
@@ -289,7 +289,6 @@
                         android:text=""
                         android:textColor="@android:color/black"
                         android:textStyle="bold"
-                        app:layout_constraintBottom_toTopOf="@id/menuItemsList"
                         app:layout_constraintLeft_toRightOf="@+id/clock_image"
                         app:layout_constraintTop_toBottomOf="@id/menuTabs">
 
@@ -322,7 +321,7 @@
                         android:visibility="gone"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent" />
+                        app:layout_constraintTop_toBottomOf="@id/menuHours"/>
 
                     <ProgressBar
                         android:id="@+id/menuProgressBar"

--- a/Density/app/src/main/res/layout/facility_info_page.xml
+++ b/Density/app/src/main/res/layout/facility_info_page.xml
@@ -277,9 +277,7 @@
                         android:visibility="invisible"
                         app:layout_constraintRight_toLeftOf="@id/menuHours"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/menuTabs">
-
-                    </ImageView>
+                        app:layout_constraintTop_toBottomOf="@id/menuTabs"/>
 
                     <TextView
                         android:id="@+id/menuHours"
@@ -335,81 +333,6 @@
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent" />
-
-                </androidx.constraintlayout.widget.ConstraintLayout>
-
-            </androidx.cardview.widget.CardView>
-
-            <TextView
-                android:id="@+id/popular_times"
-                style="@style/DTI.CardHeader"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
-                android:layout_marginTop="16dp"
-                android:text="@string/popular"
-                android:visibility="gone"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/menuCard" />
-
-            <androidx.cardview.widget.CardView
-                android:id="@+id/historicalDataCard"
-                style="@style/MyCardView"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:clickable="false"
-                android:focusable="false"
-                android:visibility="gone"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/popular_times">
-
-                <androidx.constraintlayout.widget.ConstraintLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:clipChildren="false"
-                    android:clipToPadding="false"
-                    android:orientation="vertical"
-                    android:padding="8dp"
-                    android:paddingBottom="16dp">
-
-                    <com.github.mikephil.charting.charts.BarChart
-                        android:id="@+id/densityChart"
-                        android:layout_width="match_parent"
-                        android:layout_height="275dp"
-                        android:layout_marginTop="12dp"
-                        android:layout_marginBottom="4dp"
-                        app:layout_constraintBottom_toTopOf="@+id/todayHours"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent" />
-
-                    <TextView
-                        android:id="@+id/todayHours"
-                        style="@style/DTI.Subtitle2"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="8dp"
-                        android:gravity="center"
-                        android:textSize="16sp"
-                        app:layout_constraintBottom_toTopOf="@id/todayDate"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/densityChart" />
-
-                    <TextView
-                        android:id="@+id/todayDate"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginBottom="8dp"
-                        android:gravity="center"
-                        android:textColor="@color/dark_grey"
-                        android:textSize="14sp"
-                        app:layout_constraintBottom_toTopOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/todayHours" />
 
                 </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/Density/app/src/main/res/layout/facility_info_page.xml
+++ b/Density/app/src/main/res/layout/facility_info_page.xml
@@ -307,7 +307,7 @@
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/menuTabs">
+                        app:layout_constraintTop_toBottomOf="@id/menuHours">
 
                     </androidx.recyclerview.widget.RecyclerView>
 


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request solves issue #59 by fixing layout constraints and handling edge cases in which empty menus are returned. Originally, our app showed too much blank space when there are open hours, but no menus. The new implementation adjusts this issue by reducing the blank space and adding defaultMenuText for edge cases. This pull request also fixes some minor bugs that I've encountered during testing. The app had been crashing if a facility card was clicked (1) as soon as the view loads and (2) before the initialization of RecyclerView adapter and waitTimes map. Longer facility names also overflowed after introducing #64. These issues are now resolved. I also deleted some chart layout code that is not used anymore.

- [x] Solve issue #59 
- [x] Fix adapterPosition bug
- [x] Fix waitTimes initialization bug
- [x] Fix facility_name text overflow
- [x] Delete unused layout

### Test Plan <!-- Required -->

I tested by feeding menu classes with open hours but no menus for different dining locations.

![device-2021-04-11-155254](https://user-images.githubusercontent.com/49200001/114319256-be3cb980-9ade-11eb-8708-785ecaddaab5.png)


